### PR TITLE
Adding analytic deployment instructions

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -24,15 +24,15 @@ during execution.
 ```python
 import logging
 
-# The `platform-sdk` package must be pip installed in your container
+# The `platform-sdk` package must be pip installed in your image
 import voxel51.task as voxt
 
 #
 # The following constants set paths in the internal file system of your Docker
-# container to which you want to download task input(s), write outputs, etc.
+# image to which you want to download task input(s), write outputs, etc.
 #
 
-# A directory to which to download the task input(s) for your task.
+# A directory to which to download the task input(s) for your task
 INPUTS_DIR = "/path/to/inputs"
 
 # A path to write the logfile for this task

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -20,7 +20,6 @@ that uses the Platform SDK to:
 It also demonstrates how to appropriately handle runtime errors that may occur
 during execution.
 
-
 ```python
 import logging
 
@@ -270,7 +269,7 @@ git submodule update
 #
 
 # Build image
-docker build -t "<name>-<version>" .
+docker build -t "<analytic>-<version>" .
 
 # Cleanup
 rm -rf platform-sdk

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -7,7 +7,7 @@ analytic for deployment to the Vision Services Platform.
 <img src="https://drive.google.com/uc?id=1j0S8pLsopAqF1Ik3rf-CdyAIU4kA0sOP" alt="voxel51-logo.png" width="40%"/>
 
 
-## Generic Docker entrypoint
+## Docker entrypoint
 
 The following code provides an annotated example of a generic Docker entrypoint
 that uses the Platform SDK to:

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -214,7 +214,13 @@ FROM nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04
 # Your custom installation goes here!
 #
 
+#
 # Install `platform-sdk` and its dependencies
+#
+# The following tensorflow + numpy options are supported:
+#   - Python 2.7.X: tensorflow(-gpu)==1.12.0 and numpy==1.14.0
+#   - Python 3.6.X: tensorflow(-gpu)==1.12.0 and numpy==1.16.0
+#
 COPY platform-sdk/ /engine/platform-sdk/
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -198,11 +198,11 @@ if __name__ == "__main__":
 
 ## Docker build
 
-The following section assumes that you have extended the template in the
-previous section to obtain a `main.py` entrypoint for your Docker image that
-runs your custom analytic.
+This section assumes that you have extended the template in the previous
+section to obtain a `main.py` entrypoint for your Docker image that runs your
+custom analytic.
 
-The following snippet defines a `Dockerfile` that installs the Platform SDK and
+The snippet below defines a `Dockerfile` that installs the Platform SDK and
 its dependencies in a GPU-enabled Docker image that runs the `main.py`
 entrypoint that you provide. It can be easily extended to include any custom
 installation requirements for your analytic.
@@ -210,7 +210,6 @@ installation requirements for your analytic.
 ```
 # A typical base image for GPU deployments. Others are possible
 FROM nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04
-#
 
 #
 # Your custom installation goes here!
@@ -248,7 +247,7 @@ RUN apt-get update \
 #
 ENV TASK_DESCRIPTION=null ENV=null API_TOKEN=null
 
-# Expose port so image can read/write data from external storage at runtime
+# Expose port so image can read/write from external storage at runtime
 EXPOSE 8000
 
 # Setup entrypoint

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -218,10 +218,6 @@ FROM nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04
 COPY platform-sdk/ /engine/platform-sdk/
 RUN apt-get update \
     && apt-get -y --no-install-recommends install \
-        sudo \
-        build-essential \
-        pkg-config \
-        curl \
         libcupti-dev \
         python2.7 \
         python-dev \

--- a/README.md
+++ b/README.md
@@ -51,11 +51,9 @@ addition, the platform allows users and third-party applications to deploy
 custom analytics to the platform for private use by uploading their own Docker
 images. This repository contains an easy-to-use SDK that allows you to wrap
 your custom algorithms with a Docker entrypoint that implements the platform's
-analytic interface.
-
-> Currently, to deploy a custom analytic to the Vision Services Platform you
-> must email support@voxel51.com. In the near future, you will be able to
-> deploy analytics to the platform autonomously.
+analytic interface. See the Analytic Deployment section below to learn how to
+deploy your custom analytics to the platform either programmatically via the
+API or the web-based console.
 
 Regardless of where the platform is deployed, users interact with
 it via the Vision Services API, which exposes the interface through which users
@@ -165,6 +163,55 @@ reported automatically via the Platform SDK:
 
 See the [Quickstart Guide](QUICKSTART.md) for more details about the interface
 provided by the Platform SDK.
+
+
+## Analytic Deployment
+
+You can deploy new custom analytics or new versions of your existing analytics
+at any time via the API or the web-based console. Deploying a new analytic is
+a simple two step process:
+
+- Upload an analytic JSON to the platform that describes the details and
+interface of the analytic you plan to upload. See the
+[API Documentation](https://console.voxel51.com/docs/api#analytics-download-documentation)
+for a description of the format of this JSON file.
+
+- Upload the corresponding Docker image(s) for your analytic. The platform
+supports analytic execution via either CPU-only or GPU-enabled compute. You
+must upload a separate Docker image for each execution mode for which you
+declared support in your analytic JSON.
+
+Once you have uploaded your analytic JSON and Docker images, your analytic is
+ready for production use!
+
+### Deployment via API
+
+New analytics can be published programmatically via the Vision Services API
+or any of its client libraries. For example, the following code snippet shows
+how to publish a GPU-enabled analytic using the Python client library:
+
+```py
+from voxe51.api import API
+
+# Local path to the analytic JSON file
+upload_analytic_path = "/path/to/analytic.json"
+
+# Local path to your GPU-enabled image
+upload_image_tar_path = "/path/to/image.tar.gz"
+
+api = API()
+api.upload_analytic(upload_analytic_path)
+api.upload_analytic_image(analytic_id, upload_image_tar_path, "gpu")
+```
+
+See the [API Documentation](https://console.voxel51.com/docs/api#analytics-upload-analytic)
+for more information about deploying analytics via the API.
+
+### Deployment via web console
+
+You can also publish new analytics via the web-based
+[Vision Services Console](https://console.voxel51.com). To do so, simply login
+to your platform account, navigate to the `Analytics` page, and click `Upload`.
 
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -46,14 +46,15 @@ corresponding analytic is deployed as a Pod in a Kubernetes cluster and the
 specified data is processed.
 
 The Vision Services Platform contains many publicly available analytics that
-are maintained by Voxel51. The [Analytics Documentation](https://console.voxel51.com/docs/analytics#analytics-documentation) describes the interface of these analytics in detail. In
-addition, the platform allows users and third-party applications to deploy
-custom analytics to the platform for private use by uploading their own Docker
-images. This repository contains an easy-to-use SDK that allows you to wrap
-your custom algorithms with a Docker entrypoint that implements the platform's
-analytic interface. See the Analytic Deployment section below to learn how to
-deploy your custom analytics to the platform either programmatically via the
-API or the web-based console.
+are maintained by Voxel51. The
+[Analytics Documentation](https://console.voxel51.com/docs/analytics#analytics-documentation)
+describes the interface of these analytics in detail. In addition, the platform
+allows users and third-party applications to deploy custom analytics to the
+platform for private use by uploading their own Docker images. This repository
+contains an easy-to-use SDK that allows you to wrap your custom algorithms with
+a Docker entrypoint that implements the platform's analytic interface. See the
+Analytic Deployment section below to learn how to deploy your custom analytics
+to the platform either programmatically via the API or the web-based console.
 
 Regardless of where the platform is deployed, users interact with
 it via the Vision Services API, which exposes the interface through which users
@@ -83,11 +84,12 @@ enum. This value determines which API endpoint the process should communicate
 with
 
 The following JSON file shows an example of a task specification provided to
-the `vehicle-tracker` analytic:
+the `vehicle-sense` analytic:
 
 ```json
 {
-    "analytic": "vehicle-tracker",
+    "analytic": "vehicle-sense",
+    "version": "0.1.0",
     "job_id": "2ffe1110-b446-427d-8829-db9ac95d0638",
     "inputs": {
         "video": {
@@ -110,12 +112,13 @@ the `vehicle-tracker` analytic:
 ```
 
 In the above JSON, the `analytic` key specifies the name of the analytic being
-run, and the `job_id` specifies the ID of the platform job being executed,
-which is used by the SDK when communicating the status of the task to the
-platform. The `inputs` object specifies where the process should download its
-input(s), and the `parameters` object specifies any parameters that were set.
-Finally the `output`, `status`, and `logfile` objects specify where to upload
-the task outputs, status file, and logfile, respectively.
+run, and the `version` key specifies the particular version of the analytic.
+The `job_id` specifies the ID of the platform job being executed, which is used
+by the SDK when communicating the status of the task to the platform. The
+`inputs` object specifies where the process should download its input(s), and
+the `parameters` object specifies any parameters that were set. Finally the
+`output`, `status`, and `logfile` objects specify where to upload the task
+outputs, status file, and logfile, respectively.
 
 The Platform SDK provides a `voxel51.task.TaskConfig` class that conveniently
 encapsulates reading and parsing the above specification. In particular, each
@@ -127,12 +130,13 @@ remote storage providers (Google Cloud, AWS Cloud, private data centers, etc.)
 
 As a task is being executed, the Platform SDK provides a convenient interface
 for reporting the status of the task to the platform. The following JSON file
-shows an example of the status of a completed `vehicle-tracker` task that was
+shows an example of the status of a completed `vehicle-sense` task that was
 reported automatically via the Platform SDK:
 
 ```json
 {
-    "name": "vehicle-tracker",
+    "analytic": "vehicle-sense",
+    "version": "0.1.0",
     "state": "COMPLETE",
     "start_time": "2019-02-02 07:14:28",
     "complete_time": "2019-02-02 07:32:45",

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ api.upload_analytic_image(analytic_id, upload_image_tar_path, "gpu")
 ```
 
 See the [API Documentation](https://console.voxel51.com/docs/api#analytics-upload-analytic)
-for more information about deploying analytics via the API.
+for more complete instructions for deploying analytics via the API.
 
 ### Deployment via web console
 

--- a/voxel51/task.py
+++ b/voxel51/task.py
@@ -502,12 +502,10 @@ def post_job_metadata_for_video(video_path, task_config, task_status):
     '''
     vm = voxu.get_metadata_for_video(video_path)
     metadata = {
-        "units": vm.total_frame_count,  # @todo deprecate?
         "frame_count": vm.total_frame_count,
         "duration_seconds": vm.duration,
         "size_bytes": vm.size_bytes
     }
-
     post_job_metadata(metadata, task_config, task_status)
 
 
@@ -517,7 +515,7 @@ def post_job_metadata(metadata, task_config, task_status):
     Args:
         metadata (dict): a dictionary describing the input metadata for the
             job. It should include all of the following fields, if applicable:
-            ``units``, ``frame_count``, ``duration_seconds``, ``size_bytes``
+            ``frame_count``, ``duration_seconds``, and ``size_bytes``
         task_config (TaskConfig): the TaskConfig for the task
         task_status (TaskStatus): the TaskStatus for the task
     '''

--- a/voxel51/task.py
+++ b/voxel51/task.py
@@ -49,6 +49,7 @@ class TaskConfig(Config):
 
     def __init__(self, d):
         self.analytic = self.parse_string(d, "analytic")
+        self.version = self.parse_string(d, "version")
         self.job_id = self.parse_string(d, "job_id")
         self.inputs = self.parse_object_dict(
             d, "inputs", voxu.RemotePathConfig, default={})
@@ -217,7 +218,8 @@ class TaskStatus(Serializable):
     '''Class for recording the status of a task.
 
     Attributes:
-        name (str): name of the analytic
+        analytic (str): name of the analytic
+        version (str): version of the analytic
         state (TaskState): current TaskState of the task
         start_time (str): time the task was started, or None if not started
         complete_time (str): time the task was completed, or None if not
@@ -236,7 +238,8 @@ class TaskStatus(Serializable):
         Args:
             task_config (TaskConfig): a TaskConfig instace describing the task
         '''
-        self.name = task_config.analytic
+        self.analytic = task_config.analytic
+        self.version = task_config.version
         self.state = TaskState.QUEUED
         self.start_time = None
         self.complete_time = None
@@ -323,8 +326,8 @@ class TaskStatus(Serializable):
     def attributes(self):
         '''Returns a list of class attributes to be serialized.'''
         return [
-            "name", "state", "start_time", "complete_time", "fail_time",
-            "messages", "inputs", "posted_data"]
+            "analytic", "version" "state", "start_time", "complete_time",
+            "fail_time", "messages", "inputs", "posted_data"]
 
 
 class TaskStatusMessage(Serializable):


### PR DESCRIPTION
Also removes reporting of `units` from the `post_job_metadata` route.