### PR TITLE
Moving platform SDK functionality to a `platform` subpackage

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -37,7 +37,7 @@ during execution.
 import logging
 
 # The `platform-sdk` package must be pip installed in your image
-import voxel51.task as voxt
+import voxel51.platform.task as voxt
 
 #
 # The following constants set paths in the internal file system of your Docker

--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ describes the task to be performed
 Platform API
 
 - `ENV` : specifies which deployment environment the task is being run in. The
-possible values are enumerated by the `voxel51.config.DeploymentEnvironments`
-enum. This value determines which API endpoint the process should communicate
-with
+possible values are enumerated by the
+:class:`voxel51.platform.config.DeploymentEnvironment` enum. This value
+determines which API endpoint the process should communicate with
 
 The following JSON file shows an example of a task specification provided to
 the `vehicle-sense` analytic:
@@ -121,13 +121,14 @@ the `parameters` object specifies any parameters that were set. Finally the
 `output`, `status`, and `logfile` objects specify where to upload the task
 outputs, status file, and logfile, respectively.
 
-The Platform SDK provides a `voxel51.task.TaskConfig` class that conveniently
-encapsulates reading and parsing the above specification. In particular, each
-of the remote file locations are encapsulated by the
-`voxel51.utils.RemotePathConfig` class, which abstracts the nature and location
-of the remote files from your analytic. Thus _no changes_ to your code are
-required for your analytic to support reading/writing files from different
-remote storage providers (Google Cloud, AWS Cloud, private data centers, etc.)
+The Platform SDK provides a :class:`voxel51.platform.task.TaskConfig` class
+that conveniently encapsulates reading and parsing the above specification. In
+particular, each of the remote file locations are encapsulated by the
+:class:`voxel51.platform.utils.RemotePathConfig` class, which abstracts the
+nature and location of the remote files from your analytic. Thus _no changes_
+to your code are required for your analytic to support reading/writing files
+from different remote storage providers (Google Cloud, AWS Cloud, private
+datacenters, etc.)
 
 As a task is being executed, the Platform SDK provides a convenient interface
 for reporting the status of the task to the platform. The following JSON file

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="voxel51-platform-sdk",
-    version="1.0.0",
+    version="0.1.0",
     description="Voxel51 Platform SDK",
     author="Voxel51, Inc.",
     author_email="support@voxel51.com",

--- a/voxel51/__init__.py
+++ b/voxel51/__init__.py
@@ -3,3 +3,24 @@
 | `voxel51.com <https://voxel51.com/>`_
 |
 '''
+# pragma pylint: disable=redefined-builtin
+# pragma pylint: disable=unused-wildcard-import
+# pragma pylint: disable=wildcard-import
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from builtins import *
+# pragma pylint: enable=redefined-builtin
+# pragma pylint: enable=unused-wildcard-import
+# pragma pylint: enable=wildcard-import
+
+from pkgutil import extend_path
+
+#
+# This statement allows multiple `voxel51.XXX` packages to be installed in the
+# same environment and used simultaneously.
+#
+# https://docs.python.org/2/library/pkgutil.html#pkgutil.extend_path
+#
+__path__ = extend_path(__path__, __name__)

--- a/voxel51/platform/__init__.py
+++ b/voxel51/platform/__init__.py
@@ -1,0 +1,5 @@
+'''
+| Copyright 2017-2019, Voxel51, Inc.
+| `voxel51.com <https://voxel51.com/>`_
+|
+'''

--- a/voxel51/platform/auth.py
+++ b/voxel51/platform/auth.py
@@ -32,7 +32,7 @@ class Token(object):
 
     def get_header(self):
         '''Gets a header dictionary for authenticating requests with this
-        agent token.
+        token.
 
         Returns:
             a header dictionary

--- a/voxel51/platform/config.py
+++ b/voxel51/platform/config.py
@@ -44,7 +44,7 @@ OS_ENV_VAR = "OS"
 TASK_DESCRIPTION_ENV_VAR = "TASK_DESCRIPTION"
 
 
-class DeploymentEnvironments(object):
+class DeploymentEnvironment(object):
     '''Class enumerating the possible deployment environments.'''
 
     DEV = "DEV"
@@ -56,8 +56,8 @@ class DeploymentEnvironments(object):
 # The base API URLs to use for each deployment environment
 #
 BASE_API_URLS = {
-    DeploymentEnvironments.DEV: "https://dev.api.voxel51.com/v1",
-    DeploymentEnvironments.STAGING: "https://staging.api.voxel51.com/v1",
-    DeploymentEnvironments.PROD: "https://api.voxel51.com/v1",
-    DeploymentEnvironments.LOCAL: "http://127.0.0.1:4000/v1",
+    DeploymentEnvironment.DEV: "https://dev.api.voxel51.com/v1",
+    DeploymentEnvironment.STAGING: "https://staging.api.voxel51.com/v1",
+    DeploymentEnvironment.PROD: "https://api.voxel51.com/v1",
+    DeploymentEnvironment.LOCAL: "http://127.0.0.1:4000/v1",
 }

--- a/voxel51/platform/task.py
+++ b/voxel51/platform/task.py
@@ -33,9 +33,9 @@ import eta.core.log as etal
 from eta.core.serial import Serializable
 import eta.core.utils as etau
 
-import voxel51.api as voxa
-import voxel51.config as voxc
-import voxel51.utils as voxu
+import voxel51.platform.api as voxa
+import voxel51.platform.config as voxc
+import voxel51.platform.utils as voxu
 
 
 _API_CLIENT = None
@@ -101,7 +101,8 @@ class TaskManager(object):
         URL.
 
         Args:
-            task_config_url (str): a URL from which to download a TaskConfig
+            task_config_url (str): a URL from which to download a
+                :class:`TaskConfig`
 
         Returns:
             a TaskManager instance
@@ -110,8 +111,8 @@ class TaskManager(object):
         return cls(task_config)
 
     def start(self):
-        '''Marks the task as started and publishes the TaskStatus to the
-        platform.
+        '''Marks the task as started and publishes the :class:`TaskStatus` to
+        the platform.
         '''
         start_task(self.task_status)
 
@@ -135,7 +136,7 @@ class TaskManager(object):
 
         Returns:
             a dictionary mapping parameter names to values (builtin parameters)
-                or paths (data parameters)
+            or paths (data parameters)
         '''
         return parse_parameters(
             data_params_dir, self.task_config, self.task_status)
@@ -192,8 +193,8 @@ class TaskManager(object):
                 video_path, self.task_config, self.task_status)
 
     def add_status_message(self, msg):
-        '''Adds the given status message to the TaskStatus for the task. The
-        status is not yet published to the platform.
+        '''Adds the given status message to the :class:`TaskStatus` for the
+        task. The status is not yet published to the platform.
 
         Args:
             msg (str): a status message
@@ -223,8 +224,8 @@ class TaskManager(object):
             name, output_path, self.task_config, self.task_status)
 
     def complete(self, logfile_path=None):
-        '''Marks the task as complete and publishes the TaskStatus to the
-        platform.
+        '''Marks the task as complete and publishes the :class:`TaskStatus` to
+        the platform.
 
         Args:
             logfile_path (str): an optional path to a logfile to upload for the
@@ -254,14 +255,15 @@ class TaskStatus(Serializable):
     Attributes:
         analytic (str): name of the analytic
         version (str): version of the analytic
-        state (TaskState): current TaskState of the task
+        state (TaskState): current state of the task
         start_time (str): time the task was started, or None if not started
         complete_time (str): time the task was completed, or None if not
             completed
         fail_time (str): time the task failed, or None if not failed
         failure_type (TaskFailureType): the TaskFailureType of the task, if
             applicable
-        messages (list): list of TaskStatusMessage instances for the task
+        messages (list): list of :class:`TaskStatusMessage` instances for the
+            task
         inputs (dict): a dictionary containing metadata about the inputs to the
             task
         posted_data (dict): a dictionary mapping names of outputs posted as
@@ -292,8 +294,8 @@ class TaskStatus(Serializable):
 
         Args:
             name (str): the input name
-            metadata (dict): a dictionary or Serializable object describing the
-                input
+            metadata (dict): a dictionary or ``eta.core.serial.Serializable``
+                object describing the input
         '''
         self.inputs[name] = metadata
 
@@ -352,7 +354,9 @@ class TaskStatus(Serializable):
         return message.time
 
     def publish(self):
-        '''Publishes the task status using ``self._publish_callback``.'''
+        '''Publishes the task status using
+        :func:`TaskStatus._publish_callback``.
+        '''
         self._publish_callback(self)
 
     def attributes(self):
@@ -402,20 +406,21 @@ def setup_logging(logfile_path, rotate=True):
 
 
 def get_task_config_url():
-    '''Gets the TaskConfig URL for this task from the
-    ``voxel51.config.TASK_DESCRIPTION_ENV_VAR`` environment variable.
+    '''Gets the :class:`TaskConfig` URL for this task from the
+    ``voxel51.platform.config.TASK_DESCRIPTION_ENV_VAR`` environment variable.
 
     Returns:
-        the URL from which the TaskConfig for the task can be read
+        the URL from which the :class:`TaskConfig` for the task can be read
     '''
     return os.environ[voxc.TASK_DESCRIPTION_ENV_VAR]
 
 
 def download_task_config(task_config_url):
-    '''Downloads the TaskConfig from the given URL.
+    '''Downloads the :class:`TaskConfig` from the given URL.
 
     Args:
-        task_config_url (str): the URL from which the TaskConfig can be read
+        task_config_url (str): the URL from which the :class:`TaskConfig` can
+            be read
 
     Returns:
         the TaskConfig instance
@@ -427,13 +432,13 @@ def download_task_config(task_config_url):
 
 
 def make_task_status(task_config):
-    '''Makes a TaskStatus instance for the given TaskConfig.
+    '''Makes a :class:`TaskStatus` instance for the given :class:`TaskConfig`.
 
     Args:
         task_config (TaskConfig): a TaskConfig instance describing the task
 
     Returns:
-        a TaskStatus instance for tracking the progress of the task
+        a :class:`TaskStatus` instance for tracking the progress of the task
     '''
     task_status = TaskStatus(task_config)
     logger.info("TaskStatus instance created")
@@ -441,7 +446,8 @@ def make_task_status(task_config):
 
 
 def start_task(task_status):
-    '''Marks the task as started and publishes the TaskStatus to the platform.
+    '''Marks the task as started and publishes the :class:`TaskStatus` to the
+    platform.
 
     Args:
         task_status (TaskStatus): the TaskStatus for the task
@@ -457,12 +463,12 @@ def make_publish_callback(job_id, status_path_config):
 
     Args:
         job_id (str): the ID of the underlying job
-        status_path_config (RemotePathConfig): a RemotePathConfig specifying
-            where to publish the TaskStatus
+        status_path_config (voxel51.platform.utils.RemotePathConfig): a
+            RemotePathConfig specifying how to publish the :class:`TaskStatus`
 
     Returns:
-        a function that can publish a TaskStatus instance via the syntax
-            ``publish_callback(task_status)``
+        a function that can publish a :class:`TaskStatus` instance via the
+        syntax :func:`publish_callback(task_status)`
     '''
     def _publish_status(task_status):
         voxu.upload_bytes(
@@ -520,7 +526,7 @@ def parse_parameters(data_params_dir, task_config, task_status):
 
     Returns:
         a dictionary mapping parameter names to values (builtin parameters) or
-            downloaded filepaths (data parameters)
+        downloaded filepaths (data parameters)
     '''
     parameters = {}
     for name, val in iteritems(task_config.parameters):
@@ -646,7 +652,7 @@ def upload_logfile(logfile_path, task_config):
 def fail_gracefully(
         task_config, task_status, failure_type=None, logfile_path=None):
     '''Marks the task as failed and gracefully winds up by posting any
-    available information (status, logfile, etc.).
+    available information (status, logfile, etc).
 
     Args:
         task_config (TaskConfig): the TaskConfig for the task
@@ -680,13 +686,13 @@ def fail_gracefully(
 
 
 def fail_epically(task_config_url):
-    '''Handles an epic failure of a task that occurs before the TaskConfig was
-    succesfully downloaded. The platform is notified of the failure as fully
-    as possible.
+    '''Handles an epic failure of a task that occurs before the
+    :class:`TaskConfig` was succesfully downloaded. The platform is notified
+    of the failure as fully as possible.
 
     Args:
-        task_config_url (str): the URL from which the TaskConfig was to be
-            download
+        task_config_url (str): the URL from which the :class:`TaskConfig` was
+            to be downloaded
     '''
     #
     # Log exception, even though we'll be unable to upload the logfile


### PR DESCRIPTION
The whole point of this PR is to enable the following two lines in `voxel51/__init__.py`:

```
from pkgutil import extend_path

#
# This statement allows multiple `voxel51.XXX` packages to be installed in the
# same environment and used simultaneously.
#
# https://docs.python.org/2/library/pkgutil.html#pkgutil.extend_path
#
__path__ = extend_path(__path__, __name__)
```

This is required in order to install both `api-py` and `platform-sdk` in the same virtual environment, which is a very reasonable thing to want to do.