### PR TITLE
Updates from Platform SDK troubles

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -42,7 +42,7 @@ and an API token.
 
 ## Building the image
 
-To build the demo analytic, simply run the commands below from this directory.
+To build the demo analytic, simply run the commands below **from this directory**.
 The code will clone a fresh copy of the Platform SDK, build the Docker image,
 and then cleanup the generated files.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -74,7 +74,6 @@ If you have not already, install the test server by running:
 ```shell
 cd ../tests
 npm install
-cd ../examples
 ```
 
 If you do not have `npm` installed, follow the complete install instructions
@@ -85,10 +84,10 @@ Then, run the following command to spawn a test server to run a job on the
 
 ```shell
 # Launch test server
-bash ../tests/run.bash \
+bash run.bash \
     --analytic-image platform-demo \
-    --analytic-json ./analytic.json \
-    --inputs video=data/test.mp4 \
+    --analytic-json ../examples/analytic.json \
+    --inputs video=../data/test.mp4 \
     --compute-type cpu
 ```
 


### PR DESCRIPTION
- Emphasize that example commands need to be run in `/examples` dir
- No need to `cd` into `/examples` and then run the script from there.

(IDK who needs to review this)