### PR TITLE
Fixing bug where logfiles were being double populated, or not populated at all

### DIFF
--- a/docs/linting_guide.md
+++ b/docs/linting_guide.md
@@ -71,5 +71,3 @@ https://pycodestyle.readthedocs.io/en/latest/intro.html) for more information.
 
 Copyright 2017-2019, Voxel51, Inc.<br>
 voxel51.com
-
-Brian Moore, brian@voxel51.com

--- a/docs/style_guide.md
+++ b/docs/style_guide.md
@@ -180,5 +180,3 @@ def long_function_name(
 
 Copyright 2017-2019, Voxel51, Inc.<br>
 voxel51.com
-
-Brian Moore, brian@voxel51.com

--- a/examples/i2v-demo/main.bash
+++ b/examples/i2v-demo/main.bash
@@ -1,23 +1,31 @@
 #!/bin/bash
 # Main entrypoint for an Image-to-Video container.
 #
-# Syntax:
-#   bash main.bash
+# Copyright 2017-2019, Voxel51, Inc.
+# voxel51.com
 #
 
 #
-# Don't change this path; the platform attaches a pre-stop hook to images at
-# runtime that will upload the logfile from this location whenever a task is
+# Don't change `LOGFILE_PATH`. The platform attaches a pre-stop hook to images
+# at runtime that will upload the logfile from this location whenever a task is
 # terminated unexpectedly (e.g., preemption, resource violation, etc.)
 #
 LOGFILE_PATH=/var/log/image.log
+BACKUP_LOGFILE_PATH=/var/log/backup.log
 
 #
 # Execute analytic and pipe stdout/stderr to disk so that this information
 # will be available in case of errors.
 #
-# If necessary, replace `python main.py` here with the appropriate invocation
-# for your analytic.
-#
 set -o pipefail
-python main.py 2>&1 | tee -a "${LOGFILE_PATH}"
+python main.py 2>&1 | tee "${BACKUP_LOGFILE_PATH}"
+
+# Gracefully handle uncaught failures in analytic
+if [ $? -ne 0 ]; then
+    #
+    # An uncatught exception occurred when executing the analytic, so append
+    # the backup log to the logfile, just in case
+    #
+    echo "UNCAUGHT EXCEPTION; APPENDING BACKUP LOG" >> "${LOGFILE_PATH}"
+    cat "${BACKUP_LOGFILE_PATH}" >> "${LOGFILE_PATH}"
+fi

--- a/examples/i2v-demo/main.bash
+++ b/examples/i2v-demo/main.bash
@@ -20,4 +20,4 @@ LOGFILE_PATH=/var/log/image.log
 # for your analytic.
 #
 set -o pipefail
-python main.py 2>&1 | tee "${LOGFILE_PATH}"
+python main.py 2>&1 | tee -a "${LOGFILE_PATH}"

--- a/examples/platform-demo/main.bash
+++ b/examples/platform-demo/main.bash
@@ -17,7 +17,7 @@ LOGFILE_PATH=/var/log/image.log
 # Run analytic
 # Pipes stdout/stderr to disk so that we can post it manually in case of errors
 set -o pipefail
-python main.py 2>&1 | tee "${LOGFILE_PATH}"
+python main.py 2>&1 | tee -a "${LOGFILE_PATH}"
 
 # Gracefully handle uncaught failures in analytic
 if [ $? -ne 0 ]; then

--- a/examples/platform-demo/main.bash
+++ b/examples/platform-demo/main.bash
@@ -1,32 +1,35 @@
 #!/bin/bash
-# Main entrypoint for the `platform-demo` analytic.
+# Main entrypoint for a Voxel51 Platform Analytic.
 #
 # Copyright 2017-2019, Voxel51, Inc.
 # voxel51.com
 #
-# Brian Moore, brian@voxel51.com
-#
 
 #
-# Don't change this path; the platform attaches a pre-stop hook to images at
-# runtime that will upload the logfile from this location whenever a task is
+# Don't change `LOGFILE_PATH`. The platform attaches a pre-stop hook to images
+# at runtime that will upload the logfile from this location whenever a task is
 # terminated unexpectedly (e.g., preemption, resource violation, etc.)
 #
 LOGFILE_PATH=/var/log/image.log
+BACKUP_LOGFILE_PATH=/var/log/backup.log
 
-# Run analytic
-# Pipes stdout/stderr to disk so that we can post it manually in case of errors
+#
+# Execute analytic and pipe stdout/stderr to disk so that this information
+# will be available in case of errors.
+#
 set -o pipefail
-python main.py 2>&1 | tee -a "${LOGFILE_PATH}"
+python main.py 2>&1 | tee "${BACKUP_LOGFILE_PATH}"
 
 # Gracefully handle uncaught failures in analytic
 if [ $? -ne 0 ]; then
-    # The task failed, so...
+    # Append backlog log
+    echo "UNCAUGHT EXCEPTION; APPENDING BACKUP LOG" >> "${LOGFILE_PATH}"
+    cat "${BACKUP_LOGFILE_PATH}" >> "${LOGFILE_PATH}"
 
-    # Upload the logfile
+    # Upload logfile
     curl -T "${LOGFILE_PATH}" -X PUT "${LOGFILE_SIGNED_URL}" &
 
-    # Post the job failure
+    # Post job failure
     curl -X PUT "${API_BASE_URL}/jobs/${JOB_ID}/state" \
         -H "X-Voxel51-Agent: ${API_TOKEN}" \
         -H "Content-Type: application/json" \

--- a/examples/tf-models-detector-i2v/main.bash
+++ b/examples/tf-models-detector-i2v/main.bash
@@ -1,28 +1,31 @@
 #!/bin/bash
 # Main entrypoint for an Image-to-Video container.
 #
-# Syntax:
-#   bash main.bash
-#
 # Copyright 2017-2019, Voxel51, Inc.
 # voxel51.com
 #
-# Brian Moore, brian@voxel51.com
-#
 
 #
-# Don't change this path; the platform attaches a pre-stop hook to images at
-# runtime that will upload the logfile from this location whenever a task is
+# Don't change `LOGFILE_PATH`. The platform attaches a pre-stop hook to images
+# at runtime that will upload the logfile from this location whenever a task is
 # terminated unexpectedly (e.g., preemption, resource violation, etc.)
 #
 LOGFILE_PATH=/var/log/image.log
+BACKUP_LOGFILE_PATH=/var/log/backup.log
 
 #
 # Execute analytic and pipe stdout/stderr to disk so that this information
 # will be available in case of errors.
 #
-# If necessary, replace `python main.py` here with the appropriate invocation
-# for your analytic.
-#
 set -o pipefail
-python main.py 2>&1 | tee -a "${LOGFILE_PATH}"
+python main.py 2>&1 | tee "${BACKUP_LOGFILE_PATH}"
+
+# Gracefully handle uncaught failures in analytic
+if [ $? -ne 0 ]; then
+    #
+    # An uncatught exception occurred when executing the analytic, so append
+    # the backup log to the logfile, just in case
+    #
+    echo "UNCAUGHT EXCEPTION; APPENDING BACKUP LOG" >> "${LOGFILE_PATH}"
+    cat "${BACKUP_LOGFILE_PATH}" >> "${LOGFILE_PATH}"
+fi

--- a/examples/tf-models-detector-i2v/main.bash
+++ b/examples/tf-models-detector-i2v/main.bash
@@ -25,4 +25,4 @@ LOGFILE_PATH=/var/log/image.log
 # for your analytic.
 #
 set -o pipefail
-python main.py 2>&1 | tee "${LOGFILE_PATH}"
+python main.py 2>&1 | tee -a "${LOGFILE_PATH}"

--- a/examples/tf-slim-classifier-i2v/main.bash
+++ b/examples/tf-slim-classifier-i2v/main.bash
@@ -1,28 +1,31 @@
 #!/bin/bash
 # Main entrypoint for an Image-to-Video container.
 #
-# Syntax:
-#   bash main.bash
-#
 # Copyright 2017-2019, Voxel51, Inc.
 # voxel51.com
 #
-# Brian Moore, brian@voxel51.com
-#
 
 #
-# Don't change this path; the platform attaches a pre-stop hook to images at
-# runtime that will upload the logfile from this location whenever a task is
+# Don't change `LOGFILE_PATH`. The platform attaches a pre-stop hook to images
+# at runtime that will upload the logfile from this location whenever a task is
 # terminated unexpectedly (e.g., preemption, resource violation, etc.)
 #
 LOGFILE_PATH=/var/log/image.log
+BACKUP_LOGFILE_PATH=/var/log/backup.log
 
 #
 # Execute analytic and pipe stdout/stderr to disk so that this information
 # will be available in case of errors.
 #
-# If necessary, replace `python main.py` here with the appropriate invocation
-# for your analytic.
-#
 set -o pipefail
-python main.py 2>&1 | tee -a "${LOGFILE_PATH}"
+python main.py 2>&1 | tee "${BACKUP_LOGFILE_PATH}"
+
+# Gracefully handle uncaught failures in analytic
+if [ $? -ne 0 ]; then
+    #
+    # An uncatught exception occurred when executing the analytic, so append
+    # the backup log to the logfile, just in case
+    #
+    echo "UNCAUGHT EXCEPTION; APPENDING BACKUP LOG" >> "${LOGFILE_PATH}"
+    cat "${BACKUP_LOGFILE_PATH}" >> "${LOGFILE_PATH}"
+fi

--- a/examples/tf-slim-classifier-i2v/main.bash
+++ b/examples/tf-slim-classifier-i2v/main.bash
@@ -25,4 +25,4 @@ LOGFILE_PATH=/var/log/image.log
 # for your analytic.
 #
 set -o pipefail
-python main.py 2>&1 | tee "${LOGFILE_PATH}"
+python main.py 2>&1 | tee -a "${LOGFILE_PATH}"

--- a/install.bash
+++ b/install.bash
@@ -4,8 +4,6 @@
 # Copyright 2017-2019, Voxel51, Inc.
 # voxel51.com
 #
-# Brian Moore, brian@voxel51.com
-#
 
 # Show usage information
 usage() {

--- a/quickstarts/IMAGE_TO_VIDEO.md
+++ b/quickstarts/IMAGE_TO_VIDEO.md
@@ -174,7 +174,7 @@ LOGFILE_PATH=/var/log/image.log
 # for your analytic.
 #
 set -o pipefail
-python main.py 2>&1 | tee "${LOGFILE_PATH}"
+python main.py 2>&1 | tee -a "${LOGFILE_PATH}"
 ```
 
 The script simply executes the main executable from the previous section

--- a/quickstarts/PLATFORM.md
+++ b/quickstarts/PLATFORM.md
@@ -279,7 +279,7 @@ LOGFILE_PATH=/var/log/image.log
 # for your analytic.
 #
 set -o pipefail
-python main.py 2>&1 | tee "${LOGFILE_PATH}"
+python main.py 2>&1 | tee -a "${LOGFILE_PATH}"
 
 # Gracefully handle uncaught failures in analytic
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
This bug was identified by @ecrews. Thanks!

The I2V analytic entrypoint was previously using `tee` instead of `tee -a`, which was overwriting logs from the pre-processing image. Oops!

More generally, since the Platform SDK enables Python entrypoints to write their own logs to `/var/log/image.log`, all `main.bash` scripts needed to be updated to only append its logs to the logfile in situations where the entrypoint exited with a non-zero code (in which case something may have gone so wrong that the Python code failed to log anything, so we append its entire stdout/stderr just in case and manually post to the platform).
