### PR TITLE
Ensuring all data files are included during install

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+global-include *

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,9 @@ setup(
     author="Voxel51, Inc.",
     author_email="support@voxel51.com",
     url="https://github.com/voxel51/platform-sdk",
-    license="BSD 4-clause",
+    license="BSD-4-Clause",
     packages=find_packages(),
+    include_package_data=True,
     classifiers=[
         "Development Status :: 4 - Beta",
         "Operating System :: OS Independent",
@@ -29,5 +30,6 @@ setup(
     scripts=[
         "tests/platform/test-platform",
         "tests/image2video/test-i2v",
-    ]
+    ],
+    python_requires=">=2.7",
 )


### PR DESCRIPTION
Including package data will allow `pip install` with no `-e` flag to work as expected, i.e., any data files in the repository will be copied to their expected places.

In the future, we may back off of `global-include *` to something less invasive. For now, not a big deal.