### PR TITLE
More robust handling of failures

### DIFF
--- a/examples/platform-demo/main.bash
+++ b/examples/platform-demo/main.bash
@@ -26,14 +26,12 @@ if [ $? -ne 0 ]; then
     echo "UNCAUGHT EXCEPTION; APPENDING BACKUP LOG" >> "${LOGFILE_PATH}"
     cat "${BACKUP_LOGFILE_PATH}" >> "${LOGFILE_PATH}"
 
-    # Upload logfile
-    curl -T "${LOGFILE_PATH}" -X PUT "${LOGFILE_SIGNED_URL}" &
-
     # Post job failure
     curl -X PUT "${API_BASE_URL}/jobs/${JOB_ID}/state" \
         -H "X-Voxel51-Agent: ${API_TOKEN}" \
         -H "Content-Type: application/json" \
-        -d '{"state": "FAILED", "failure_type": "ANALYTIC"}' &
+        -d '{"state": "FAILED", "failure_type": "ANALYTIC"}'
 
-    wait
+    # Upload logfile
+    curl -T "${LOGFILE_PATH}" -X PUT "${LOGFILE_SIGNED_URL}"
 fi

--- a/pylintrc
+++ b/pylintrc
@@ -66,7 +66,7 @@ confidence=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 #disable=import-star-module-level,old-octal-literal,oct-method,print-statement,unpacking-in-except,parameter-unpacking,backtick,old-raise-syntax,old-ne-operator,long-suffix,dict-view-method,dict-iter-method,metaclass-assignment,next-method-called,raising-string,indexing-exception,raw_input-builtin,long-builtin,file-builtin,execfile-builtin,coerce-builtin,cmp-builtin,buffer-builtin,basestring-builtin,apply-builtin,filter-builtin-not-iterating,using-cmp-argument,useless-suppression,range-builtin-not-iterating,suppressed-message,no-absolute-import,old-division,cmp-method,reload-builtin,zip-builtin-not-iterating,intern-builtin,unichr-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,input-builtin,round-builtin,hex-method,nonzero-method,map-builtin-not-iterating
-disable=too-few-public-methods,too-many-instance-attributes,too-many-arguments,too-many-locals,too-many-lines,non-iterator-returned,too-many-statements
+disable=too-few-public-methods,too-many-instance-attributes,too-many-arguments,too-many-locals,too-many-lines,non-iterator-returned,too-many-statements,useless-object-inheritance
 
 
 [REPORTS]

--- a/quickstarts/PLATFORM.md
+++ b/quickstarts/PLATFORM.md
@@ -285,22 +285,20 @@ if [ $? -ne 0 ]; then
     echo "UNCAUGHT EXCEPTION; APPENDING BACKUP LOG" >> "${LOGFILE_PATH}"
     cat "${BACKUP_LOGFILE_PATH}" >> "${LOGFILE_PATH}"
 
-    # Upload logfile
-    curl -T "${LOGFILE_PATH}" -X PUT "${LOGFILE_SIGNED_URL}" &
-
     # Post job failure
     curl -X PUT "${API_BASE_URL}/jobs/${JOB_ID}/state" \
         -H "X-Voxel51-Agent: ${API_TOKEN}" \
         -H "Content-Type: application/json" \
-        -d '{"state": "FAILED", "failure_type": "ANALYTIC"}' &
+        -d '{"state": "FAILED", "failure_type": "ANALYTIC"}'
 
-    wait
+    # Upload logfile
+    curl -T "${LOGFILE_PATH}" -X PUT "${LOGFILE_SIGNED_URL}"
 fi
 ```
 
 The script simply executes the main executable from the previous section, pipes
 its `stdout` and `stderr` to disk, and, if the executable exits with a non-zero
-status code, uploads the logfile to the platform and marks the job as `FAILED`.
+status code, marks the job as `FAILED` and uploads the logfile to the platform.
 
 This extra layer of protection is important to catch and appropriately report
 errors that prevent the Platform SDK from loading (e.g., an `import` error

--- a/voxel51/platform/config.py
+++ b/voxel51/platform/config.py
@@ -19,7 +19,7 @@ from builtins import *
 
 
 #
-# The environment variable that will hold the URL from which to download the
+# The environment variable that holds the URL from which to download the
 # TaskConfig for the task
 #
 TASK_DESCRIPTION_ENV_VAR = "TASK_DESCRIPTION"
@@ -39,3 +39,9 @@ API_TOKEN_ENV_VAR = "API_TOKEN"
 # The environment variable that holds the base URL of the API
 #
 API_BASE_URL_ENV_VAR = "API_BASE_URL"
+
+#
+# The environment variable that holds the URL to which to upload the logfile
+# for the task
+#
+LOGFILE_SIGNED_URL_ENV_VAR = "LOGFILE_SIGNED_URL"

--- a/voxel51/platform/task.py
+++ b/voxel51/platform/task.py
@@ -878,46 +878,44 @@ def fail_gracefully(
         logfile_path (str, optional): an optional path to a logfile for the
             task to upload
     '''
-    # Log the stack trace and mark the task as failed
-    exc_info = sys.exc_info()
+    # Log the error
     if failure_type is not None:
         logger.info("Failure type: %s", failure_type)
     else:
         logger.info("Failure type not specified")
-    logger.error("Uncaught exception", exc_info=exc_info)
+    logger.error("Uncaught exception", exc_info=sys.exc_info())
+
+    # Mark the task as failed
     task_status.fail(failure_type=failure_type)
 
     try:
         # Try to publish the task status
         task_status.publish()
     except:
-        logger.error("Failed to publish job status")
+        logger.error("Failed to publish task status", exc_info=sys.exc_info())
 
     try:
-        # Try to upload the logfile, if any
+        # Try to upload the logfile, if requested
         if logfile_path:
             upload_logfile(logfile_path, task_config)
     except:
-        logger.error("Failed to upload logfile")
+        logger.error("Failed to upload logfile", exc_info=sys.exc_info())
 
 
-def fail_epically():
+def fail_epically(logfile_path=None):
     '''Handles an epic failure of a task that occurs before the
     :class:`TaskConfig` was succesfully downloaded. The platform is notified
     of the failure as fully as possible.
+
+    Args:
+        logfile_path (str, optional): an optional path to a logfile for the
+            task to upload
     '''
-    #
-    # Log exception, even though we'll be unable to upload the logfile
-    # because something went wrong before we were even able to parse the
-    # task config to get the logfile path
-    #
+    # Log the error
     logger.error("Uncaught exception", exc_info=sys.exc_info())
 
     try:
-        #
-        # The only thing we can do is update the job status to FAILED
-        # and blame it on the platform
-        #
+        # Update the job status to FAILED and blame it on the platform
         job_id = os.environ[voxc.JOB_ID_ENV_VAR]
         _get_api_client().update_job_state(
             job_id, TaskState.FAILED, failure_type=TaskFailureType.PLATFORM)
@@ -925,7 +923,17 @@ def fail_epically():
             "Job state %s (%s) posted to API", TaskState.FAILED,
             TaskFailureType.PLATFORM)
     except:
-        logger.error("Unable to communicate with API")
+        logger.error("Unable to communicate with API", exc_info=sys.exc_info())
+
+    try:
+        # Try to upload the logfile, if requested
+        if logfile_path:
+            logfile_url = os.environ[voxc.LOGFILE_SIGNED_URL_ENV_VAR]
+            logfile = RemotePathConfig.from_signed_url(logfile_url)
+            logger.info("Uploading logfile to %s", str(logfile))
+            voxu.upload(logfile_path, logfile)
+    except:
+        logger.error("Failed to upload logfile", exc_info=sys.exc_info())
 
 
 def _get_api_client():

--- a/voxel51/platform/task.py
+++ b/voxel51/platform/task.py
@@ -669,10 +669,9 @@ def make_publish_callback(job_id, status_path_config):
         syntax :func:`publish_callback(task_status)`
     '''
     def _publish_status(task_status):
-        voxu.upload_bytes(
-            task_status.to_str(), status_path_config,
-            content_type="application/json")
-        logger.info("Task status written to cloud storage")
+        #
+        # Report job state to platform
+        #
 
         if task_status.state == TaskState.FAILED:
             failure_type = task_status.failure_type
@@ -681,12 +680,23 @@ def make_publish_callback(job_id, status_path_config):
 
         _get_api_client().update_job_state(
             job_id, task_status.state, failure_type=failure_type)
+
         if task_status.state == TaskState.FAILED:
             logger.info(
                 "Job state %s (%s) posted to API", task_status.state,
                 failure_type)
         else:
             logger.info("Job state %s posted to API", task_status.state)
+
+        #
+        # Post current task status
+        #
+
+        voxu.upload_bytes(
+            task_status.to_str(), status_path_config,
+            content_type="application/json")
+
+        logger.info("Task status written to cloud storage")
 
     return _publish_status
 

--- a/voxel51/platform/task.py
+++ b/voxel51/platform/task.py
@@ -937,7 +937,7 @@ def fail_epically(logfile_path=None):
 
 
 def _get_api_client():
-    global _API_CLIENT
+    global _API_CLIENT  # pylint: disable=global-statement
     if _API_CLIENT is None:
         _API_CLIENT = voxa.make_api_client()
     return _API_CLIENT


### PR DESCRIPTION
Addresses the spirit of https://github.com/voxel51/platform-sdk/issues/23.

**Release Notes**
- since the `LOGFILE_SIGNED_URL` environment variable is populated, jobs _can_ actually post their logfiles in _epic failure_ scenarios. Thus, `voxel51.platform.task.fail_epically()` has been updated to support that
- ensures that platform API calls to update the state of a job happen _first_, before posting any status/logfiles

The latter change is subtle, but it ensures that jobs will be successfully marked as `FAILED` inside `voxel51.platform.task.fail_gracefully()`, where, previously, if the task status URL was broken, this would result in an unhandled exception that would have prevented the job from being marked as failed.