### PR TITLE
Example I2V semantic segmentation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ for deployment to the Voxel51 Platform.
 Also, see the
 [examples folder](https://github.com/voxel51/platform-sdk/tree/develop/examples)
 for an end-to-end example of building and deploying a test analytic to the
-platform.
+Platform.
 
 ### Image-To-Video Analytics
 
@@ -82,30 +82,30 @@ Image-To-Video tool.
 
 The Voxel51 Platform is a scalable compute cluster that allows users to process
 their video (or other) data through state-of-the-art video understanding
-algorithms. The platform is generic and can be deployed in the cloud
+algorithms. The Platform is generic and can be deployed in the cloud
 (Google Cloud, AWS, Microsoft Azure, etc.) or on-premises in a private
 datacenter.
 
-Algorithms are deployed to the platform as **analytics**, which are concrete
+Algorithms are deployed to the Platform as **analytics**, which are concrete
 processing modules that take video (or other) data as input and output metadata
 (e.g., object detections, image classifications, etc.) in a predefined format.
 In turn, users can create **jobs** to run analytics on data they have uploaded
-to the platform. Each analytic is deployed to the platform as a Docker
-container. When a job is requested on the platform, the Docker image for the
+to the Platform. Each analytic is deployed to the Platform as a Docker
+container. When a job is requested on the Platform, the Docker image for the
 corresponding analytic is deployed as a Pod in a Kubernetes cluster and the
 specified data is processed.
 
-The platform contains many publicly available analytics that are maintained by
+The Platform contains many publicly available analytics that are maintained by
 Voxel51. The [Analytics Documentation](https://voxel51.com/docs/analytics#analytics-documentation)
-describes the interface of these analytics in detail. In addition, the platform
+describes the interface of these analytics in detail. In addition, the Platform
 allows users and third-party applications to deploy custom analytics to the
-platform for private use by uploading their own Docker images. This repository
+Platform for private use by uploading their own Docker images. This repository
 contains an easy-to-use SDK that allows you to wrap your custom algorithms with
-a Docker entrypoint that implements the platform's analytic interface. See the
+a Docker entrypoint that implements the Platform's analytic interface. See the
 Analytic Deployment section below to learn how to deploy your custom analytics
-to the platform either programmatically via the API or the web-based console.
+to the Platform either programmatically via the API or the web-based console.
 
-Regardless of where the platform is deployed, users interact with it via the
+Regardless of where the Platform is deployed, users interact with it via the
 Platform API, which exposes the interface through which users can upload and
 manage data resources, run analytics on data, monitor the status of their jobs,
 download the outputs of jobs, access statements and billing, and more. For more
@@ -115,10 +115,10 @@ information about the Platform API, refer to the
 
 ## Analytic interface
 
-All analytics deployed to the platform must be implemented as Docker containers
-that support the platform's interface as described below.
+All analytics deployed to the Platform must be implemented as Docker containers
+that support the Platform's interface as described below.
 
-The platform communicates with analytic Docker images by setting the following
+The Platform communicates with analytic Docker images by setting the following
 environment variables:
 
 - `TASK_DESCRIPTION` : the URL from which to download a JSON file that
@@ -147,7 +147,7 @@ are required for your analytic to support reading/writing files from different
 remote storage providers (Google Cloud, AWS Cloud, private datacenters, etc.)
 
 As a task is being executed, the Platform SDK provides a convenient interface
-for reporting the status of the task to the platform. The following JSON file
+for reporting the status of the task to the Platform. The following JSON file
 shows an example of the status of a completed `voxel51/vehicle-sense` task that
 was reported automatically via the Platform SDK:
 
@@ -196,12 +196,12 @@ at any time via the [API](https://voxel51.com/docs/api) or the
 [Web Console](https://console.voxel51.com). Deploying a new analytic is a
 simple two step process:
 
-- Upload an analytic JSON to the platform that describes the details and
+- Upload an analytic JSON to the Platform that describes the details and
 interface of the analytic you plan to upload. See the
 [API Documentation](https://voxel51.com/docs/api#analytics-download-documentation)
 for a description of the format of this JSON file.
 
-- Upload the corresponding Docker image(s) for your analytic. The platform
+- Upload the corresponding Docker image(s) for your analytic. The Platform
 supports analytic execution via either CPU-only or GPU-enabled compute. You
 must upload a separate Docker image for each execution mode for which you
 declared support in your analytic JSON.
@@ -217,7 +217,7 @@ publish a GPU-enabled analytic using the
 [Python client library](https://github.com/voxel51/api-py):
 
 ```py
-from voxel51.users.api import API, AnalyticType
+from voxel51.users.api import API, AnalyticImageType
 
 analytic_json_path = "/path/to/analytic.json"
 gpu_image_path = "/path/to/gpu-image.tar.gz"
@@ -225,12 +225,11 @@ gpu_image_path = "/path/to/gpu-image.tar.gz"
 api = API()
 
 # Upload analytic JSON
-analytic_type = AnalyticType.PLATFORM
-analytic = api.upload_analytic(analytic_json_path, analytic_type=analytic_type)
+analytic = api.upload_analytic(analytic_json_path)
 analytic_id = analytic["id"]
 
 # Upload image
-api.upload_analytic_image(analytic_id, gpu_image_path, "gpu")
+api.upload_analytic_image(analytic_id, gpu_image_path, AnalyticImageType.GPU)
 ```
 
 See the [API Documentation](https://voxel51.com/docs/api#analytics-upload-analytic)
@@ -240,7 +239,7 @@ for more complete instructions for deploying analytics via the API.
 
 You can also publish new analytics via the Platform's
 [Web Console](https://console.voxel51.com). To do so, simply login
-to your platform account, navigate to the `Analytics` page, and click `Upload`.
+to your Platform account, navigate to the `Analytics` page, and click `Upload`.
 
 
 ## Documentation
@@ -259,5 +258,5 @@ your browser.
 
 ## Copyright
 
-Copyright 2017-2019, Voxel51, Inc.<br>
+Copyright 2017-2020, Voxel51, Inc.<br>
 [voxel51.com](https://voxel51.com)

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,10 +12,11 @@ This folder contains examples of deploying analytics to the
 | [i2v-demo](i2v-demo/README.md) | Image-To-Video | Example of deploying a simple Image-To-Video analytic that generates random video labels |
 | [tf-models-detector-i2v](tf-models-detector-i2v/README.md) | Image-To-Video | Example of deploying an object detector from the [TensorFlow Detection Model Zoo](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/detection_model_zoo.md) as an Image-To-Video analytic |
 | [tf-models-segmenter-i2v](tf-models-segmenter-i2v/README.md) | Image-To-Video | Example of deploying an instance segmentation model from the [TensorFlow Detection Model Zoo](https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/detection_model_zoo.md) as an Image-To-Video analytic |
+| [tf-semantic-segmenter-i2v](tf-semantic-segmenter-i2v/README.md) | Image-To-Video | Example of deploying a semantic segmentation model stored as a frozen TensorFlow graph as an Image-To-Video analytic |
 | [tf-slim-classifier-i2v](tf-slim-classifier-i2v/README.md) | Image-To-Video | Example of deploying a classifier from the [TensorFlow-Slim Model Zoo](https://github.com/tensorflow/models/tree/master/research/slim) as an Image-To-Video analytic |
 
 
 ## Copyright
 
-Copyright 2017-2019, Voxel51, Inc.<br>
+Copyright 2017-2020, Voxel51, Inc.<br>
 [voxel51.com](https://voxel51.com)

--- a/examples/i2v-demo/README.md
+++ b/examples/i2v-demo/README.md
@@ -30,43 +30,35 @@ the algorithm and its dependencies
 
 ## Environment setup
 
-First, install the Platform SDK with a full ETA installation:
+First, install a fresh copy of the Platform SDK with a full ETA installation
+inside this directory. Yes, a fresh copy, not the version of the SDK that you
+cloned in order to access the file you're reading. This new copy of the SDK
+will be copied into the Docker image that you build.
 
-> Note: you probably want to do this in a fresh virtual environment so you
-> don't interfere with your existing ETA installation!
+> Note: you probably want to install this in a fresh virtual environment to
+> avoid interfering with your existing environment
 
 ```shell
-# Install Platform SDK
 git clone https://github.com/voxel51/platform-sdk
 cd platform-sdk
-git submodule init
-git submodule update
 
-# Full ETA install
-cd eta
-bash install.bash
-cp config-example.json config.json
-
-cd ../..
+bash install.bash -f
 ```
 
 
 ## Building the image
 
-To build the image, run the following commands:
+To build the image, run the following command:
 
 ```shell
 # Build the image
 docker build --tag i2v-demo .
-
-# Cleanup
-rm -rf platform-sdk
 ```
 
 
 ## Testing locally
 
-Before deploying analytics to the platform, it is helpful to test the Docker
+Before deploying analytics to the Platform, it is helpful to test the Docker
 images locally to ensure that they are functioning properly. The Platform SDK
 provides a `test-i2v` script that you can use to perform such tests. Type
 `test-i2v -h` to learn more about the script.
@@ -99,22 +91,24 @@ After your analytic image passes local tests, it is ready for deployment to
 the Voxel51 Platform!
 
 
-## Deploying to the platform
+## Deploying to the Platform
 
 To deploy your analytic to the Platform, you must first save the Docker image
-as a `.tar.gz` file:
+as a tarfile:
 
 ```shell
 docker save i2v-demo | gzip -c > i2v-demo.tar.gz
 ```
 
-The following code snippet publishes the analytic to the platform using the
+### Deploying via Python client library
+
+The following code snippet publishes the analytic to the Platform using the
 Python client library. In order to run it, you must have first followed the
 [installation instructions in the README](../../README.md#installation)
 to get setup with a Platform Account, the Python client, and an API token.
 
 ```py
-from voxel51.users.api import API, AnalyticType
+from voxel51.users.api import API, AnalyticType, AnalyticImageType
 
 analytic_json_path = "./analytic.json"
 cpu_image_path = "./i2v-demo.tar.gz"
@@ -122,22 +116,40 @@ cpu_image_path = "./i2v-demo.tar.gz"
 api = API()
 
 # Upload analytic JSON
-analytic_type = AnalyticType.IMAGE_TO_VIDEO
-analytic = api.upload_analytic(analytic_json_path, analytic_type=analytic_type)
+analytic = api.upload_analytic(
+    analytic_json_path, analytic_type=AnalyticType.IMAGE_TO_VIDEO)
 analytic_id = analytic["id"]
 
 # Upload image
-api.upload_analytic_image(analytic_id, cpu_image_path, "cpu")
+api.upload_analytic_image(analytic_id, cpu_image_path, AnalyticImageType.CPU)
 ```
 
-You can also upload analytics via your
+### Deploying via CLI
+
+You can also upload analytics via the `voxel51` CLI that is automatically
+installed with the Python client library:
+
+```shell
+ANALYTIC_DOC_PATH=./analytic.json
+CPU_IMAGE_PATH=./i2v-demo.tar.gz
+
+# Upload analytic JSON
+ANALYTIC_ID=$(voxel51 analytics upload $ANALYTIC_DOC_PATH -t IMAGE_TO_VIDEO --print-id)
+
+# Upload image
+voxel51 analytics upload-image -i $ANALYTIC_ID -p $CPU_IMAGE_PATH -t CPU
+```
+
+### Deploying via Platform Console
+
+Finally, you can upload analytics via your
 [Platform Console account](https://console.voxel51.com).
 
 
-## Using the analytic on the platform
+## Using the analytic on the Platform
 
 After the analytic has been processed and is ready for use (check the Platform
-Console to verify), you can run a test platform job on the `data/people.mp4`
+Console to verify), you can run a test Platform job on the `data/people.mp4`
 video by executing the following code with the Python client library:
 
 ```py
@@ -159,10 +171,10 @@ api.wait_until_job_completes(job["id"])
 api.download_job_output(job["id"], "out/labels.json")
 ```
 
-In the above, replace `<username>` with your username on the platform.
+In the above, replace `<username>` with your username on the Platform.
 
 
 ## Copyright
 
-Copyright 2017-2019, Voxel51, Inc.<br>
+Copyright 2017-2020, Voxel51, Inc.<br>
 [voxel51.com](https://voxel51.com)

--- a/examples/i2v-demo/README.md
+++ b/examples/i2v-demo/README.md
@@ -43,6 +43,8 @@ git clone https://github.com/voxel51/platform-sdk
 cd platform-sdk
 
 bash install.bash -f
+
+cd ..
 ```
 
 

--- a/examples/platform-demo/README.md
+++ b/examples/platform-demo/README.md
@@ -36,9 +36,12 @@ image that you build.
 ```shell
 # Clone Platform SDK
 git clone https://github.com/voxel51/platform-sdk
+
+# Initialize submodules
 cd platform-sdk
 git submodule init
 git submodule update
+
 cd ..
 ```
 

--- a/examples/platform-demo/README.md
+++ b/examples/platform-demo/README.md
@@ -26,9 +26,12 @@ the inputs and outputs that the analytic exposes
 the analytic and its dependencies
 
 
-## Building the image
+## Environment setup
 
-To build the image, run the following commands:
+First, clone a fresh copy of the Platform SDK inside this directory. Yes, a
+fresh copy, not the version of the SDK that you cloned in order to access the
+file you're reading. This new copy of the SDK will be copied into the Docker
+image that you build.
 
 ```shell
 # Clone Platform SDK
@@ -37,18 +40,22 @@ cd platform-sdk
 git submodule init
 git submodule update
 cd ..
+```
 
-# Build image
+
+## Building the image
+
+To build the image, run the following command:
+
+```shell
+# Build the image
 docker build --tag platform-demo .
-
-# Cleanup
-rm -rf platform-sdk
 ```
 
 
 ## Testing locally
 
-Before deploying analytics to the platform, it is helpful to test the Docker
+Before deploying analytics to the Platform, it is helpful to test the Docker
 images locally to ensure that they are functioning properly. The Platform SDK
 provides a `test-platform` script that you can use to perform such tests.
 Type `test-plaform -h` to learn more about the script.
@@ -68,12 +75,12 @@ test-platform \
     --analytic-image platform-demo \
     --analytic-json analytic.json \
     --inputs video=data/test.mp4 \
-    --compute-type cpu
+    --compute-type CPU
 ```
 
 The server will print a `docker run` command that you should execute in
 another terminal. This will locally execute the job that you specified, using
-your test server as a proxy for the platform. An `out/` directory will be
+your test server as a proxy for the Platform. An `out/` directory will be
 populated with the various files read and written by the analytic as it
 executes.
 
@@ -88,22 +95,24 @@ After your analytic image passes local tests, it is ready for deployment to
 the Voxel51 Platform!
 
 
-## Deploying to the platform
+## Deploying to the Platform
 
 To deploy your analytic to the Platform, you must first save the Docker image
-as a `.tar.gz` file:
+as a tarfile:
 
 ```shell
 docker save platform-demo | gzip -c > platform-demo.tar.gz
 ```
 
-The following code snippet publishes the analytic to the platform using the
+### Deploying via Python client library
+
+The following code snippet publishes the analytic to the Platform using the
 Python client library. In order to run it, you must have first followed the
 [installation instructions in the README](../../README.md#installation)
 to get setup with a Platform Account, the Python client, and an API token.
 
 ```py
-from voxel51.users.api import API
+from voxel51.users.api import API, AnalyticImageType
 
 analytic_json_path = "./analytic.json"
 cpu_image_path = "./platform-demo.tar.gz"
@@ -115,17 +124,35 @@ analytic = api.upload_analytic(analytic_json_path)
 analytic_id = analytic["id"]
 
 # Upload image
-api.upload_analytic_image(analytic_id, cpu_image_path, "cpu")
+api.upload_analytic_image(analytic_id, cpu_image_path, AnalyticImageType.CPU)
 ```
 
-You can also upload analytics via your
+### Deploying via CLI
+
+You can also upload analytics via the `voxel51` CLI that is automatically
+installed with the Python client library:
+
+```shell
+ANALYTIC_DOC_PATH=./analytic.json
+CPU_IMAGE_PATH=./platform-demo.tar.gz
+
+# Upload analytic JSON
+ANALYTIC_ID=$(voxel51 analytics upload $ANALYTIC_DOC_PATH --print-id)
+
+# Upload image
+voxel51 analytics upload-image -i $ANALYTIC_ID -p $CPU_IMAGE_PATH -t CPU
+```
+
+### Deploying via Platform Console
+
+Finally, you can upload analytics via your
 [Platform Console account](https://console.voxel51.com).
 
 
-## Using the analytic on the platform
+## Using the analytic on the Platform
 
 After the analytic has been processed and is ready for use (check the Platform
-Console to verify), you can run a test platform job on the `data/test.mp4`
+Console to verify), you can run a test Platform job on the `data/test.mp4`
 video by executing the following code with the Python client library:
 
 ```py
@@ -147,10 +174,10 @@ api.wait_until_job_completes(job["id"])
 api.download_job_output(job["id"], "out/labels.json")
 ```
 
-In the above, replace `<username>` with your username on the platform.
+In the above, replace `<username>` with your username on the Platform.
 
 
 ## Copyright
 
-Copyright 2017-2019, Voxel51, Inc.<br>
+Copyright 2017-2020, Voxel51, Inc.<br>
 [voxel51.com](https://voxel51.com)

--- a/examples/tf-models-detector-i2v/README.md
+++ b/examples/tf-models-detector-i2v/README.md
@@ -44,6 +44,8 @@ git clone https://github.com/voxel51/platform-sdk
 cd platform-sdk
 
 bash install.bash -f
+
+cd ..
 ```
 
 

--- a/examples/tf-models-detector-i2v/README.md
+++ b/examples/tf-models-detector-i2v/README.md
@@ -3,7 +3,8 @@
 This directory demonstrates how to deploy a detector from the
 [TensorFlow Detection Model Zoo](
 https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/detection_model_zoo.md)
-to the Voxel51 Platform via the Image-To-Video tool.
+to the [Voxel51 Platform](https://console.voxel51.com) using the Image-To-Video
+tool from the Platform SDK.
 
 
 ## Overview
@@ -31,11 +32,12 @@ the analytic and its dependencies
 ## Environment setup
 
 First, install a fresh copy of the Platform SDK with a full ETA installation
-inside this directory. This version of the SDK will be copied into the Docker
-image that you build.
+inside this directory. Yes, a fresh copy, not the version of the SDK that you
+cloned in order to access the file you're reading. This new copy of the SDK
+will be copied into the Docker image that you build.
 
-> Note: you probably want to do this in a fresh virtual environment to avoid
-> interfering with your existing environment
+> Note: you probably want to install this in a fresh virtual environment to
+> avoid interfering with your existing environment
 
 ```shell
 git clone https://github.com/voxel51/platform-sdk
@@ -106,9 +108,6 @@ docker build \
     --build-arg TENSORFLOW_VERSION="${TENSORFLOW_VERSION}" \
     --tag "${IMAGE_NAME}" \
     .
-
-# Cleanup
-rm -rf platform-sdk
 ```
 
 
@@ -179,7 +178,7 @@ Python client library. In order to run it, you must have first followed the
 to get setup with a Platform Account, the Python client, and an API token.
 
 ```py
-from voxel51.users.api import API, AnalyticType
+from voxel51.users.api import API, AnalyticType, AnalyticImageType
 
 analytic_json_path = "./analytic.json"
 cpu_image_path = "./tf-models-detector-i2v-cpu.tar.gz"
@@ -188,13 +187,13 @@ gpu_image_path = "./tf-models-detector-i2v-gpu.tar.gz"
 api = API()
 
 # Upload analytic JSON
-analytic_type = AnalyticType.IMAGE_TO_VIDEO
-analytic = api.upload_analytic(analytic_json_path, analytic_type=analytic_type)
+analytic = api.upload_analytic(
+    analytic_json_path, analytic_type=AnalyticType.IMAGE_TO_VIDEO)
 analytic_id = analytic["id"]
 
 # Upload images
-api.upload_analytic_image(analytic_id, cpu_image_path, "cpu")
-api.upload_analytic_image(analytic_id, gpu_image_path, "gpu")
+api.upload_analytic_image(analytic_id, cpu_image_path, AnalyticImageType.CPU)
+api.upload_analytic_image(analytic_id, gpu_image_path, AnalyticImageType.GPU)
 ```
 
 ### Deploying via CLI
@@ -208,11 +207,11 @@ CPU_IMAGE_PATH=./tf-models-detector-i2v-cpu.tar.gz
 GPU_IMAGE_PATH=./tf-models-detector-i2v-gpu.tar.gz
 
 # Upload analytic JSON
-ANALYTIC_ID=$(voxel51 analytics upload $ANALYTIC_DOC_PATH --print-id)
+ANALYTIC_ID=$(voxel51 analytics upload $ANALYTIC_DOC_PATH -t IMAGE_TO_VIDEO --print-id)
 
 # Upload images
-voxel51 analytics upload --image $ANALYTIC_ID --path $CPU_IMAGE_PATH --image-type cpu
-voxel51 analytics upload --image $ANALYTIC_ID --path $GPU_IMAGE_PATH --image-type gpu
+voxel51 analytics upload-image -i $ANALYTIC_ID -p $CPU_IMAGE_PATH -t CPU
+voxel51 analytics upload-image -i $ANALYTIC_ID -p $GPU_IMAGE_PATH -t GPU
 ```
 
 ### Deploying via Platform Console

--- a/examples/tf-models-segmenter-i2v/README.md
+++ b/examples/tf-models-segmenter-i2v/README.md
@@ -44,6 +44,8 @@ git clone https://github.com/voxel51/platform-sdk
 cd platform-sdk
 
 bash install.bash -f
+
+cd ..
 ```
 
 

--- a/examples/tf-models-segmenter-i2v/README.md
+++ b/examples/tf-models-segmenter-i2v/README.md
@@ -17,8 +17,8 @@ The following files constitute the definition of the analytic:
 gracefully handles any uncaught errors that are raised therein
 
 - `main.py`: the main executable for the analytic, which loads the model using
-the `eta.detectors.TFModelsSegmenter` interface, performs inference on each
-frame provided by the pre-processing container, and saves the resulting
+the `eta.detectors.TFModelsInstanceSegmenter` interface, performs inference on
+each frame provided by the pre-processing container, and saves the resulting
 predictions as an `eta.core.video.VideoLabels` JSON file on disk
 
 - `analytic.json`: the analytic JSON file for the analytic, which declares

--- a/examples/tf-models-segmenter-i2v/README.md
+++ b/examples/tf-models-segmenter-i2v/README.md
@@ -3,7 +3,8 @@
 This directory demonstrates how to deploy an instance segmentation model from
 the [TensorFlow Detection Model Zoo](
 https://github.com/tensorflow/models/blob/master/research/object_detection/g3doc/detection_model_zoo.md)
-to the Voxel51 Platform via the Image-To-Video tool.
+to the [Voxel51 Platform](https://console.voxel51.com) using the Image-To-Video
+tool from the Platform SDK.
 
 
 ## Overview
@@ -31,11 +32,12 @@ the analytic and its dependencies
 ## Environment setup
 
 First, install a fresh copy of the Platform SDK with a full ETA installation
-inside this directory. This version of the SDK will be copied into the Docker
-image that you build.
+inside this directory. Yes, a fresh copy, not the version of the SDK that you
+cloned in order to access the file you're reading. This new copy of the SDK
+will be copied into the Docker image that you build.
 
-> Note: you probably want to do this in a fresh virtual environment to avoid
-> interfering with your existing environment
+> Note: you probably want to install this in a fresh virtual environment to
+> avoid interfering with your existing environment
 
 ```shell
 git clone https://github.com/voxel51/platform-sdk
@@ -106,9 +108,6 @@ docker build \
     --build-arg TENSORFLOW_VERSION="${TENSORFLOW_VERSION}" \
     --tag "${IMAGE_NAME}" \
     .
-
-# Cleanup
-rm -rf platform-sdk
 ```
 
 
@@ -179,7 +178,7 @@ Python client library. In order to run it, you must have first followed the
 to get setup with a Platform Account, the Python client, and an API token.
 
 ```py
-from voxel51.users.api import API, AnalyticType
+from voxel51.users.api import API, AnalyticType, AnalyticImageType
 
 analytic_json_path = "./analytic.json"
 cpu_image_path = "./tf-models-segmenter-i2v-cpu.tar.gz"
@@ -188,13 +187,13 @@ gpu_image_path = "./tf-models-segmenter-i2v-gpu.tar.gz"
 api = API()
 
 # Upload analytic JSON
-analytic_type = AnalyticType.IMAGE_TO_VIDEO
-analytic = api.upload_analytic(analytic_json_path, analytic_type=analytic_type)
+analytic = api.upload_analytic(
+    analytic_json_path, analytic_type=AnalyticType.IMAGE_TO_VIDEO)
 analytic_id = analytic["id"]
 
 # Upload images
-api.upload_analytic_image(analytic_id, cpu_image_path, "cpu")
-api.upload_analytic_image(analytic_id, gpu_image_path, "gpu")
+api.upload_analytic_image(analytic_id, cpu_image_path, AnalyticImageType.CPU)
+api.upload_analytic_image(analytic_id, gpu_image_path, AnalyticImageType.GPU)
 ```
 
 ### Deploying via CLI
@@ -208,11 +207,11 @@ CPU_IMAGE_PATH=./tf-models-segmenter-i2v-cpu.tar.gz
 GPU_IMAGE_PATH=./tf-models-segmenter-i2v-gpu.tar.gz
 
 # Upload analytic JSON
-ANALYTIC_ID=$(voxel51 analytics upload $ANALYTIC_DOC_PATH --print-id)
+ANALYTIC_ID=$(voxel51 analytics upload $ANALYTIC_DOC_PATH -t IMAGE_TO_VIDEO --print-id)
 
 # Upload images
-voxel51 analytics upload --image $ANALYTIC_ID --path $CPU_IMAGE_PATH --image-type cpu
-voxel51 analytics upload --image $ANALYTIC_ID --path $GPU_IMAGE_PATH --image-type gpu
+voxel51 analytics upload-image -i $ANALYTIC_ID -p $CPU_IMAGE_PATH -t CPU
+voxel51 analytics upload-image -i $ANALYTIC_ID -p $GPU_IMAGE_PATH -t GPU
 ```
 
 ### Deploying via Platform Console

--- a/examples/tf-models-segmenter-i2v/main.py
+++ b/examples/tf-models-segmenter-i2v/main.py
@@ -2,7 +2,7 @@
 '''
 Entrypoint for the `tf-models-segmenter-i2v` container.
 
-Copyright 2017-2019, Voxel51, Inc.
+Copyright 2017-2020, Voxel51, Inc.
 voxel51.com
 
 Brian Moore, brian@voxel51.com
@@ -22,7 +22,8 @@ from builtins import *
 import logging
 
 import eta.core.image as etai
-from eta.detectors import TFModelsSegmenter, TFModelsSegmenterConfig
+from eta.detectors import TFModelsInstanceSegmenter, \
+                          TFModelsInstanceSegmenterConfig
 
 import voxel51.image2video.core as voxc
 
@@ -54,13 +55,13 @@ def main():
 
 
 def load_model():
-    config = TFModelsSegmenterConfig({
+    config = TFModelsInstanceSegmenterConfig({
         "model_path": MODEL_PATH,
         "labels_path": LABELS_PATH,
         "mask_thresh": MASK_THRESHOLD,
         "confidence_thresh": CONFIDENCE_THRESHOLD,
     })
-    return TFModelsSegmenter(config)
+    return TFModelsInstanceSegmenter(config)
 
 
 def process_image(model, img):

--- a/examples/tf-semantic-segmenter-i2v/.gitignore
+++ b/examples/tf-semantic-segmenter-i2v/.gitignore
@@ -1,0 +1,9 @@
+*.tar.gz
+
+data/
+out/
+platform-sdk/
+api-py/
+
+models/*
+!models/cityscapes-train-labels.txt

--- a/examples/tf-semantic-segmenter-i2v/Dockerfile
+++ b/examples/tf-semantic-segmenter-i2v/Dockerfile
@@ -1,0 +1,52 @@
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+
+#
+# Install `platform-sdk` and its dependencies
+#
+# `ppa:deadsnakes/ppa` is used in order to install Python 3.6 on Ubuntu 16.04
+# https://askubuntu.com/questions/865554/how-do-i-install-python-3-6-using-apt-get
+#
+# `https://bootstrap.pypa.io/get-pip.py` is used to install pip on Python 3.6
+# https://askubuntu.com/questions/889535/how-to-install-pip-for-python-3-6-on-ubuntu-16-10
+#
+COPY platform-sdk/ /engine/platform-sdk/
+ARG TENSORFLOW_VERSION
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install software-properties-common \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update \
+    && apt-get -y --no-install-recommends install \
+        sudo \
+        build-essential \
+        git \
+        curl \
+        wget \
+        unzip \
+        pkg-config \
+        ca-certificates \
+        python3.6 \
+        python3.6-dev \
+        libcupti-dev \
+        ffmpeg \
+        imagemagick \
+    && ln -s /usr/bin/python3.6 /usr/local/bin/python \
+    && curl https://bootstrap.pypa.io/get-pip.py | python \
+    && pip install --upgrade pip setuptools \
+    && pip --no-cache-dir install -r /engine/platform-sdk/requirements.txt \
+    && pip --no-cache-dir install -r /engine/platform-sdk/eta/requirements.txt \
+    && pip --no-cache-dir install -e /engine/platform-sdk/. \
+    && pip --no-cache-dir install -e /engine/platform-sdk/eta/. \
+    && pip --no-cache-dir install -I $TENSORFLOW_VERSION \
+    && pip --no-cache-dir install --upgrade numpy==1.16.0 \
+    && rm -rf /var/lib/apt
+
+# Install models
+COPY models/ /engine/models/
+
+# Setup entrypoint
+COPY main.bash /engine/main.bash
+COPY main.py /engine/main.py
+RUN mkdir -p /var/log
+WORKDIR /engine
+ENTRYPOINT ["bash", "main.bash"]

--- a/examples/tf-semantic-segmenter-i2v/README.md
+++ b/examples/tf-semantic-segmenter-i2v/README.md
@@ -1,8 +1,9 @@
 # Deploying a Semantic Segmentation Model via the Image-To-Video Tool
 
 This directory demonstrates how to deploy a semantic segmentation model stored
-as a frozen TensorFlow graph to the Voxel51 Platform via the Image-To-Video
-tool.
+as a frozen TensorFlow graph to the
+[Voxel51 Platform](https://console.voxel51.com) using the Image-To-Video tool
+from the Platform SDK.
 
 
 ## Overview
@@ -30,11 +31,12 @@ the analytic and its dependencies
 ## Environment setup
 
 First, install a fresh copy of the Platform SDK with a full ETA installation
-inside this directory. This version of the SDK will be copied into the Docker
-image that you build.
+inside this directory. Yes, a fresh copy, not the version of the SDK that you
+cloned in order to access the file you're reading. This new copy of the SDK
+will be copied into the Docker image that you build.
 
-> Note: you probably want to do this in a fresh virtual environment to avoid
-> interfering with your existing environment
+> Note: you probably want to install this in a fresh virtual environment to
+> avoid interfering with your existing environment
 
 ```shell
 git clone https://github.com/voxel51/platform-sdk
@@ -83,9 +85,6 @@ docker build \
     --build-arg TENSORFLOW_VERSION="${TENSORFLOW_VERSION}" \
     --tag "${IMAGE_NAME}" \
     .
-
-# Cleanup
-rm -rf platform-sdk
 ```
 
 
@@ -156,7 +155,7 @@ Python client library. In order to run it, you must have first followed the
 to get setup with a Platform Account, the Python client, and an API token.
 
 ```py
-from voxel51.users.api import API, AnalyticType
+from voxel51.users.api import API, AnalyticType, AnalyticImageType
 
 analytic_json_path = "./analytic.json"
 cpu_image_path = "./tf-semantic-segmenter-i2v-cpu.tar.gz"
@@ -165,13 +164,13 @@ gpu_image_path = "./tf-semantic-segmenter-i2v-gpu.tar.gz"
 api = API()
 
 # Upload analytic JSON
-analytic_type = AnalyticType.IMAGE_TO_VIDEO
-analytic = api.upload_analytic(analytic_json_path, analytic_type=analytic_type)
+analytic = api.upload_analytic(
+    analytic_json_path, analytic_type=AnalyticType.IMAGE_TO_VIDEO)
 analytic_id = analytic["id"]
 
 # Upload images
-api.upload_analytic_image(analytic_id, cpu_image_path, "cpu")
-api.upload_analytic_image(analytic_id, gpu_image_path, "gpu")
+api.upload_analytic_image(analytic_id, cpu_image_path, AnalyticImageType.CPU)
+api.upload_analytic_image(analytic_id, gpu_image_path, AnalyticImageType.GPU)
 ```
 
 ### Deploying via CLI
@@ -185,11 +184,11 @@ CPU_IMAGE_PATH=./tf-semantic-segmenter-i2v-cpu.tar.gz
 GPU_IMAGE_PATH=./tf-semantic-segmenter-i2v-gpu.tar.gz
 
 # Upload analytic JSON
-ANALYTIC_ID=$(voxel51 analytics upload $ANALYTIC_DOC_PATH --print-id)
+ANALYTIC_ID=$(voxel51 analytics upload $ANALYTIC_DOC_PATH -t IMAGE_TO_VIDEO --print-id)
 
 # Upload images
-voxel51 analytics upload --image $ANALYTIC_ID --path $CPU_IMAGE_PATH --image-type cpu
-voxel51 analytics upload --image $ANALYTIC_ID --path $GPU_IMAGE_PATH --image-type gpu
+voxel51 analytics upload-image -i $ANALYTIC_ID -p $CPU_IMAGE_PATH -t CPU
+voxel51 analytics upload-image -i $ANALYTIC_ID -p $GPU_IMAGE_PATH -t GPU
 ```
 
 ### Deploying via Platform Console

--- a/examples/tf-semantic-segmenter-i2v/README.md
+++ b/examples/tf-semantic-segmenter-i2v/README.md
@@ -43,6 +43,8 @@ git clone https://github.com/voxel51/platform-sdk
 cd platform-sdk
 
 bash install.bash -f
+
+cd ..
 ```
 
 
@@ -56,9 +58,17 @@ Download the frozen inference graph from the ETA Models Registry by running the
 command below:
 
 ```shell
-# Downloads a pre-trained DeepLabV3 semantic segmentation model from the ETA
+#
+# Download a pre-trained DeepLabV3 semantic segmentation model from the ETA
 # models registry
+#
+
+# Option 1: a larger (~160MB) DeepLabV3 model
 eta gdrive download --public 1GKJtItUirHZ2DY_mQu872QuoWZuAHNr8 \
+    models/frozen_inference_graph.pb
+
+# Option 2: a smaller (~8MB) DeepLabV3 model
+eta gdrive download --public 1JYx2Z6or9Jm24aWv79-5aQ8Gg9IF_m6Z \
     models/frozen_inference_graph.pb
 ```
 

--- a/examples/tf-semantic-segmenter-i2v/README.md
+++ b/examples/tf-semantic-segmenter-i2v/README.md
@@ -1,0 +1,232 @@
+# Deploying a Semantic Segmentation Model via the Image-To-Video Tool
+
+This directory demonstrates how to deploy a semantic segmentation model stored
+as a frozen TensorFlow graph to the Voxel51 Platform via the Image-To-Video
+tool.
+
+
+## Overview
+
+This directory defines a `tf-semantic-segmenter-i2v` analytic that is ready for
+deployment to the Voxel51 Platform.
+
+The following files constitute the definition of the analytic:
+
+- `main.bash`: the main Docker entrypoint script, which calls `main.py` and
+gracefully handles any uncaught errors that are raised therein
+
+- `main.py`: the main executable for the analytic, which loads the model using
+the `eta.segmenters.TFSemanticSegmenter` interface, performs inference on each
+frame provided by the pre-processing container, and saves the resulting
+predictions as an `eta.core.video.VideoLabels` JSON file on disk
+
+- `analytic.json`: the analytic JSON file for the analytic, which declares
+the inputs and outputs that the analytic exposes
+
+- `Dockerfile`: the Dockerfile that specifies how to build an image containing
+the analytic and its dependencies
+
+
+## Environment setup
+
+First, install a fresh copy of the Platform SDK with a full ETA installation
+inside this directory. This version of the SDK will be copied into the Docker
+image that you build.
+
+> Note: you probably want to do this in a fresh virtual environment to avoid
+> interfering with your existing environment
+
+```shell
+git clone https://github.com/voxel51/platform-sdk
+cd platform-sdk
+
+bash install.bash -f
+```
+
+
+## Model setup
+
+For this example, we'll use pre-trained DeepLabV3 semantic segmentation model
+that was trained on the
+[Cityscapes dataset](https://www.cityscapes-dataset.com).
+
+Download the frozen inference graph from the ETA Models Registry by running the
+command below:
+
+```shell
+# Downloads a pre-trained DeepLabV3 semantic segmentation model from the ETA
+# models registry
+eta gdrive download --public 1GKJtItUirHZ2DY_mQu872QuoWZuAHNr8 \
+    models/frozen_inference_graph.pb
+```
+
+
+## Building the image
+
+To build the image, run the following commands:
+
+```shell
+# For GPU build
+BASE_IMAGE="nvidia/cuda:9.0-cudnn7-runtime-ubuntu16.04"
+TENSORFLOW_VERSION="tensorflow-gpu==1.12.0"
+IMAGE_NAME="tf-semantic-segmenter-i2v-gpu"
+
+# For CPU build
+BASE_IMAGE="ubuntu:16.04"
+TENSORFLOW_VERSION="tensorflow==1.12.0"
+IMAGE_NAME="tf-semantic-segmenter-i2v-cpu"
+
+# Build the image
+docker build \
+    --file Dockerfile \
+    --build-arg BASE_IMAGE="${BASE_IMAGE}" \
+    --build-arg TENSORFLOW_VERSION="${TENSORFLOW_VERSION}" \
+    --tag "${IMAGE_NAME}" \
+    .
+
+# Cleanup
+rm -rf platform-sdk
+```
+
+
+## Testing locally
+
+Before deploying analytics to the Platform, it is helpful to test the Docker
+images locally to ensure that they are functioning properly. The Platform SDK
+provides a `test-i2v` script that you can use to perform such tests. Type
+`test-i2v -h` to learn more about the script.
+
+To test your analytic locally, first download a directory of frames to work
+with:
+
+```shell
+mkdir -p data
+wget -O data/people.tar.gz 'https://drive.google.com/uc?export=download&id=1zi7oCKjmZ0ectl4xgn7r3V4DiUKrgZuk'
+wget -O data/people.mp4 'https://drive.google.com/uc?export=download&id=1daYF-MZkdJs3BKjcAQMRBFxkndovfkiw'
+tar -xf data/people.tar.gz -C data/
+rm data/people.tar.gz
+```
+
+Then run the image on the frames using the `test-i2v` script:
+
+```shell
+test-i2v "${IMAGE_NAME}" data/people
+```
+
+If the script executed correctly, it will write an `out/labels.json` file in
+your working directory that contains the predictions generated for each input
+frame.
+
+To visualize the labels on the input video, run the following ETA pipeline,
+which will generate an `out/people-annotated.mp4` file:
+
+```shell
+VIDEO_PATH=data/people.mp4
+LABELS_PATH=out/labels.json
+ANNOTATED_VIDEO_PATH=out/people-annotated.mp4
+
+eta build -n visualize_labels \
+    -i "video=\"${VIDEO_PATH}\",video_labels=\"${LABELS_PATH}\"" \
+    -o "annotated_video=\"${ANNOTATED_VIDEO_PATH}\"" \
+    --run-now
+```
+
+To cleanup after the test, run `test-i2v -c` from the same working directory in
+which you ran the test script.
+
+After your analytic image passes local tests, it is ready for deployment to
+the Platform!
+
+
+## Deploying to the Platform
+
+To deploy your working analytic to the Platform, you must first save the Docker
+images as tarfiles:
+
+```shell
+docker save tf-semantic-segmenter-i2v-cpu | gzip -c > tf-semantic-segmenter-i2v-cpu.tar.gz
+docker save tf-semantic-segmenter-i2v-gpu | gzip -c > tf-semantic-segmenter-i2v-gpu.tar.gz
+```
+
+### Deploying via Python client library
+
+The following code snippet publishes the analytic to the Platform using the
+Python client library. In order to run it, you must have first followed the
+[installation instructions in the README](../../README.md#installation)
+to get setup with a Platform Account, the Python client, and an API token.
+
+```py
+from voxel51.users.api import API, AnalyticType
+
+analytic_json_path = "./analytic.json"
+cpu_image_path = "./tf-semantic-segmenter-i2v-cpu.tar.gz"
+gpu_image_path = "./tf-semantic-segmenter-i2v-gpu.tar.gz"
+
+api = API()
+
+# Upload analytic JSON
+analytic_type = AnalyticType.IMAGE_TO_VIDEO
+analytic = api.upload_analytic(analytic_json_path, analytic_type=analytic_type)
+analytic_id = analytic["id"]
+
+# Upload images
+api.upload_analytic_image(analytic_id, cpu_image_path, "cpu")
+api.upload_analytic_image(analytic_id, gpu_image_path, "gpu")
+```
+
+### Deploying via CLI
+
+You can also upload analytics via the `voxel51` CLI that is automatically
+installed with the Python client library:
+
+```shell
+ANALYTIC_DOC_PATH=./analytic.json
+CPU_IMAGE_PATH=./tf-semantic-segmenter-i2v-cpu.tar.gz
+GPU_IMAGE_PATH=./tf-semantic-segmenter-i2v-gpu.tar.gz
+
+# Upload analytic JSON
+ANALYTIC_ID=$(voxel51 analytics upload $ANALYTIC_DOC_PATH --print-id)
+
+# Upload images
+voxel51 analytics upload --image $ANALYTIC_ID --path $CPU_IMAGE_PATH --image-type cpu
+voxel51 analytics upload --image $ANALYTIC_ID --path $GPU_IMAGE_PATH --image-type gpu
+```
+
+### Deploying via Platform Console
+
+Finally, you can upload analytics via your
+[Platform Console account](https://console.voxel51.com).
+
+
+## Using the analytic on the Platform
+
+After the analytic has been processed and is ready for use (check the Platform
+Console to verify), you can run a test Platform job on the `data/people.mp4`
+video by executing the following code with the Python client library:
+
+```py
+from voxel51.users.api import API
+from voxel51.users.jobs import JobRequest
+
+api = API()
+
+# Upload data
+data = api.upload_data("data/people.mp4")
+
+# Upload and start job
+job_request = JobRequest("<username>/tf-semantic-segmenter-i2v")
+job_request.set_input("video", data_id=data["id"])
+job = api.upload_job_request(job_request, data["name"], auto_start=True)
+
+# Wait until job completes, then download output
+api.wait_until_job_completes(job["id"])
+api.download_job_output(job["id"], "out/labels.json")
+```
+
+In the above, replace `<username>` with your username on the Platform.
+
+
+## Copyright
+
+Copyright 2017-2020, Voxel51, Inc.<br>
+[voxel51.com](https://voxel51.com)

--- a/examples/tf-semantic-segmenter-i2v/analytic.json
+++ b/examples/tf-semantic-segmenter-i2v/analytic.json
@@ -1,0 +1,9 @@
+{
+    "info": {
+        "version": "0.1",
+        "name": "tf-semantic-segmenter-i2v",
+        "supports_cpu": true,
+        "supports_gpu": true,
+        "description": "An analytic that operates a frame-based semantic segmentation model stored as a frozen TensorFlow graph"
+    }
+}

--- a/examples/tf-semantic-segmenter-i2v/main.bash
+++ b/examples/tf-semantic-segmenter-i2v/main.bash
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Main entrypoint for an Image-to-Video container.
+#
+# Copyright 2017-2019, Voxel51, Inc.
+# voxel51.com
+#
+
+#
+# Don't change `LOGFILE_PATH`. The platform attaches a pre-stop hook to images
+# at runtime that will upload the logfile from this location whenever a task is
+# terminated unexpectedly (e.g., preemption, resource violation, etc.)
+#
+LOGFILE_PATH=/var/log/image.log
+BACKUP_LOGFILE_PATH=/var/log/backup.log
+
+#
+# Execute analytic and pipe stdout/stderr to disk so that this information
+# will be available in case of errors.
+#
+set -o pipefail
+python main.py 2>&1 | tee "${BACKUP_LOGFILE_PATH}"
+
+# Gracefully handle uncaught failures in analytic
+if [ $? -ne 0 ]; then
+    #
+    # An uncatught exception occurred when executing the analytic, so append
+    # the backup log to the logfile, just in case
+    #
+    echo "UNCAUGHT EXCEPTION; APPENDING BACKUP LOG" >> "${LOGFILE_PATH}"
+    cat "${BACKUP_LOGFILE_PATH}" >> "${LOGFILE_PATH}"
+fi

--- a/examples/tf-semantic-segmenter-i2v/main.py
+++ b/examples/tf-semantic-segmenter-i2v/main.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+'''
+Entrypoint for the `tf-semantic-segmenter-i2v` container.
+
+Copyright 2017-2020, Voxel51, Inc.
+voxel51.com
+
+Brian Moore, brian@voxel51.com
+'''
+# pragma pylint: disable=redefined-builtin
+# pragma pylint: disable=unused-wildcard-import
+# pragma pylint: disable=wildcard-import
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from builtins import *
+# pragma pylint: enable=redefined-builtin
+# pragma pylint: enable=unused-wildcard-import
+# pragma pylint: enable=wildcard-import
+
+import logging
+
+from eta.segmenters import TFSemanticSegmenter, TFSemanticSegmenterConfig
+
+import voxel51.image2video.core as voxc
+
+
+logger = logging.getLogger(__name__)
+
+
+MODEL_PATH = "/engine/models/frozen_inference_graph.pb"
+LABELS_PATH = "/engine/models/cityscapes-train-labels.txt"
+
+
+def main():
+    voxc.setup_logging()
+
+    logger.info("Loading model")
+    model = load_model()
+
+    with model:
+        logger.info("Performing predictions")
+        predictions = voxc.Predictions()
+        for img, frame_number in voxc.read_images():
+            image_labels = process_image(model, img)
+            predictions.add(frame_number, image_labels)
+
+    logger.info("Writing predictions to disk")
+    voxc.write_predictions(predictions)
+
+
+def load_model():
+    config = TFSemanticSegmenterConfig({
+        "model_path": MODEL_PATH,
+        "labels_path": LABELS_PATH,
+        "resize_to_max_dim": 513,
+        "input_name": "ImageTensor",
+        "output_name": "SemanticPredictions"
+    })
+    return TFSemanticSegmenter(config)
+
+
+def process_image(model, img):
+    return model.segment(img)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tf-semantic-segmenter-i2v/models/cityscapes-train-labels.txt
+++ b/examples/tf-semantic-segmenter-i2v/models/cityscapes-train-labels.txt
@@ -1,0 +1,20 @@
+0:road
+1:sidewalk
+2:building
+3:wall
+4:fence
+5:pole
+6:traffic light
+7:traffic sign
+8:vegetation
+9:terrain
+10:sky
+11:person
+12:rider
+13:car
+14:truck
+15:bus
+16:train
+17:motorcycle
+18:bicycle
+255:other

--- a/examples/tf-slim-classifier-i2v/README.md
+++ b/examples/tf-slim-classifier-i2v/README.md
@@ -2,7 +2,8 @@
 
 This directory demonstrates how to deploy an image classifier from the
 [TensorFlow-Slim Model Zoo](https://github.com/tensorflow/models/tree/master/research/slim)
-to the Voxel51 Platform via the Image-To-Video tool.
+to the [Voxel51 Platform](https://console.voxel51.com) using the Image-To-Video
+tool from the Platform SDK.
 
 
 ## Overview
@@ -30,11 +31,12 @@ the analytic and its dependencies
 ## Environment setup
 
 First, install a fresh copy of the Platform SDK with a full ETA installation
-inside this directory. This version of the SDK will be copied into the Docker
-image that you build.
+inside this directory. Yes, a fresh copy, not the version of the SDK that you
+cloned in order to access the file you're reading. This new copy of the SDK
+will be copied into the Docker image that you build.
 
-> Note: you probably want to do this in a fresh virtual environment to avoid
-> interfering with your existing environment
+> Note: you probably want to install this in a fresh virtual environment to
+> avoid interfering with your existing environment
 
 ```shell
 git clone https://github.com/voxel51/platform-sdk
@@ -130,9 +132,6 @@ docker build \
     --build-arg TENSORFLOW_VERSION="${TENSORFLOW_VERSION}" \
     --tag "${IMAGE_NAME}" \
     .
-
-# Cleanup
-rm -rf platform-sdk
 ```
 
 
@@ -203,7 +202,7 @@ Python client library. In order to run it, you must have first followed the
 to get setup with a Platform Account, the Python client, and an API token.
 
 ```py
-from voxel51.users.api import API, AnalyticType
+from voxel51.users.api import API, AnalyticType, AnalyticImageType
 
 analytic_json_path = "./analytic.json"
 cpu_image_path = "./tf-slim-classifier-i2v-cpu.tar.gz"
@@ -212,13 +211,13 @@ gpu_image_path = "./tf-slim-classifier-i2v-gpu.tar.gz"
 api = API()
 
 # Upload analytic JSON
-analytic_type = AnalyticType.IMAGE_TO_VIDEO
-analytic = api.upload_analytic(analytic_json_path, analytic_type=analytic_type)
+analytic = api.upload_analytic(
+    analytic_json_path, analytic_type=AnalyticType.IMAGE_TO_VIDEO)
 analytic_id = analytic["id"]
 
 # Upload images
-api.upload_analytic_image(analytic_id, cpu_image_path, "cpu")
-api.upload_analytic_image(analytic_id, gpu_image_path, "gpu")
+api.upload_analytic_image(analytic_id, cpu_image_path, AnalyticImageType.CPU)
+api.upload_analytic_image(analytic_id, gpu_image_path, AnalyticImageType.GPU)
 ```
 
 ### Deploying via CLI
@@ -232,11 +231,11 @@ CPU_IMAGE_PATH=./tf-slim-classifier-i2v-cpu.tar.gz
 GPU_IMAGE_PATH=./tf-slim-classifier-i2v-gpu.tar.gz
 
 # Upload analytic JSON
-ANALYTIC_ID=$(voxel51 analytics upload $ANALYTIC_DOC_PATH --print-id)
+ANALYTIC_ID=$(voxel51 analytics upload $ANALYTIC_DOC_PATH -t IMAGE_TO_VIDEO --print-id)
 
 # Upload images
-voxel51 analytics upload --image $ANALYTIC_ID --path $CPU_IMAGE_PATH --image-type cpu
-voxel51 analytics upload --image $ANALYTIC_ID --path $GPU_IMAGE_PATH --image-type gpu
+voxel51 analytics upload-image -i $ANALYTIC_ID -p $CPU_IMAGE_PATH -t CPU
+voxel51 analytics upload-image -i $ANALYTIC_ID -p $GPU_IMAGE_PATH -t GPU
 ```
 
 ### Deploying via Platform Console

--- a/examples/tf-slim-classifier-i2v/README.md
+++ b/examples/tf-slim-classifier-i2v/README.md
@@ -43,6 +43,8 @@ git clone https://github.com/voxel51/platform-sdk
 cd platform-sdk
 
 bash install.bash -f
+
+cd ..
 ```
 
 

--- a/quickstarts/IMAGE_TO_VIDEO.md
+++ b/quickstarts/IMAGE_TO_VIDEO.md
@@ -283,9 +283,6 @@ cd ..
 
 # Build image
 docker build -t "<image-name>" .
-
-# Cleanup
-rm -rf platform-sdk
 ```
 
 

--- a/quickstarts/PLATFORM.md
+++ b/quickstarts/PLATFORM.md
@@ -398,9 +398,6 @@ cd ..
 
 # Build image
 docker build -t "<image-name>" .
-
-# Cleanup
-rm -rf platform-sdk
 ```
 
 
@@ -418,7 +415,7 @@ test-platform \
     --analytic-image <image-name> \
     --analytic-json <analytic-json> \
     --inputs <name>=<path> \
-    --compute-type <cpu|gpu>
+    --compute-type <CPU|GPU>
 ```
 
 Type `test-platform -h` for help, and see the
@@ -443,5 +440,5 @@ to publish your analytic to the platform.
 
 ## Copyright
 
-Copyright 2017-2019, Voxel51, Inc.<br>
+Copyright 2017-2020, Voxel51, Inc.<br>
 [voxel51.com](https://voxel51.com)

--- a/tests/platform/README.md
+++ b/tests/platform/README.md
@@ -27,7 +27,7 @@ Example usage
     --analytic-image <image-name> \
     --analytic-json <analytic-json> \
     --inputs <name>=<path> \
-    --compute-type <cpu|gpu>
+    --compute-type <CPU|GPU>
 
 Options
 
@@ -37,7 +37,7 @@ Options
                                     times if necessary. At least one input is required.
   -p, --parameters <name>=<value>   Name=value pair(s) specifying parameter settings to use. `value` must be JSON
                                     parsable. Can be repeated multiple times if  necessary.
-  --compute-type <cpu|gpu>          The compute type to use. Your Docker image must support this compute type. If
+  --compute-type <CPU|GPU>          The compute type to use. Your Docker image must support this compute type. If
                                     GPU execution is requested, `--runtime=nvidia` is added to the `docker run`
                                     command; it is assumed that your machine and Docker installation are
                                     configured to support this.

--- a/tests/platform/server/index.js
+++ b/tests/platform/server/index.js
@@ -60,7 +60,7 @@ const optionDefinitions = [
       'this compute type. If GPU execution is requested, `--runtime=nvidia` ' +
       'is added to the `docker run` command; it is assumed that your ' +
       'machine and Docker installation are configured to support this.',
-    typeLabel: '<cpu|gpu>',
+    typeLabel: '<CPU|GPU>',
   },
   {
     name: 'clean',
@@ -93,7 +93,7 @@ const usageDefinition = [
       '--analytic-image <image-name> \\\n' +
       '--analytic-json <analytic-json> \\\n' +
       '--inputs <name>=<path> \\\n' +
-      '--compute-type <cpu|gpu>'
+      '--compute-type <CPU|GPU>'
   },
   {
     header: 'Options',
@@ -260,7 +260,7 @@ const JOB_ID = uuid4();
     return new Promise(function(resolve, reject) {
       debug('Generating the docker run command.');
       let cmd = 'docker run ';
-      if (COMPUTE_TYPE === 'gpu') {
+      if (COMPUTE_TYPE.toUpperCase() === 'GPU') {
         cmd += '--runtime=nvidia ';
       }
       cmd += `--name ${JOB_ID} ` +


### PR DESCRIPTION
**TODO BEFORE MERGING THIS PR**
Merge https://github.com/voxel51/eta/pull/436 and update ETA submodule in this repository

**Release notes**
- Adds an end-to-end example of deploying a semantic segmentation model to the Platform as an Image-To-Video analytic
- Cleans up all examples, including updating them to use the latest API features

**More information about the semantic segmentation example**
The example uses a pre-trained DeepLabV3 model from ETA trained on the Cityscapes dataset.

Example output on one frame of a video:
![test-segmented](https://user-images.githubusercontent.com/25985824/75072122-d01b6180-54c4-11ea-9ffb-6065abb6e402.png)
