### PR TITLE
test-i2v: Ensure that output directory exists before running

### DIFF
--- a/tests/image2video/test-i2v
+++ b/tests/image2video/test-i2v
@@ -54,6 +54,8 @@ fi
 OUTPUT_DIR="$(pwd)/out"
 FRAMES_DIR="$(pwd)/$2"
 
+mkdir -p "${OUTPUT_DIR}"
+
 # Run test
 docker run --rm \
     -v "${FRAMES_DIR}":/shared/user/inputs/frames/ \


### PR DESCRIPTION
If the container creates `out`, it's owned by root, which causes both `test-i2v -c` and the example ETA pipeline to fail